### PR TITLE
fixing TypeError: data argument

### DIFF
--- a/starter_notebook.ipynb
+++ b/starter_notebook.ipynb
@@ -237,6 +237,8 @@
         "print('Loaded data and skipped {}/{} lines since contained in test set.'.format(len(skip_lines), i))\n",
         "    \n",
         "df = pd.DataFrame(zip(source, target), columns=['source_sentence', 'target_sentence'])\n",
+        "# if you get TypeError: data argument can't be an iterator is because of your zip version run this below\n",
+         "#df = pd.DataFrame(list(zip(source, target)), columns=['source_sentence', 'target_sentence'])\n",
         "df.head(3)"
       ],
       "execution_count": 0,


### PR DESCRIPTION
if you get TypeError: data argument can't be an iterator is because of the ```zip``` version you are using