### PR TITLE
Add jw300 english afrikaans

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 ![Slack Status](https://img.shields.io/twitter/follow/MasakhaneMt?label=Follow&style=social)
 
 
-We need African researchers from ACROSS the continent to join our effort in building translation models for African languages. Masakhane means "We Build Together" in isiZulu. Phase 1 consists of getting baseline translation results for as many languages as possible. Phase 2 consists of combining all our powers and doing some transfer learning to get significant improvement on the models. 
+We need African researchers from ACROSS the continent to join our effort in building translation models for African languages. Masakhane means "We Build Together" in isiZulu. Phase 1 consists of getting baseline translation results for as many languages as possible. Phase 2 consists of combining all our powers and doing some transfer learning to get significant improvement on the models.
 
 First, we encourage you read up on our website: [masakhane.io](https://masakhane.io)
 
-All language pairs that we currently have benchmarks for can be found [here](https://github.com/masakhane-io/masakhane/tree/master/en-zu/autshumato-baseline)
+All language pairs that we currently have benchmarks for can be found [here](https://github.com/masakhane-io/masakhane/tree/master/language_pairs.md)
 
 ## Outcomes
 
-1. Put African NLP on the map by publishing a paper at a top-tier NLP conference featuring as many languages and countries and researchers as possible. 
+1. Put African NLP on the map by publishing a paper at a top-tier NLP conference featuring as many languages and countries and researchers as possible.
 2. Faciliate the development of an NLP community in Africa
 
 3. Spur research and focus on African languages, by providing a starting point for other researchers to begin
@@ -48,7 +48,7 @@ We have an [example colab notebook](https://github.com/jaderabbit/masakhane/blob
 
 ### 2. Finding data for my language?!
 
-This is a huge challenge, but luckily we have a place to start! At ACL 2019, [this](https://www.aclweb.org/anthology/P19-1310/) paper was published. The short story? Turns out the Jehovah's Witness community has been translating many many documents and not all of them are religious. And their language representation is DIVERSE. 
+This is a huge challenge, but luckily we have a place to start! At ACL 2019, [this](https://www.aclweb.org/anthology/P19-1310/) paper was published. The short story? Turns out the Jehovah's Witness community has been translating many many documents and not all of them are religious. And their language representation is DIVERSE.
 
 Check out this spreadsheet [HERE](https://docs.google.com/spreadsheets/d/1p_HpKkrAlRDte04pgStsxaN8IJ4I0GgidVGIE_6VtMw/edit?usp=sharing) to see if your language is featured, then go to Opus to find the links to the data:  http://opus.nlpl.eu/JW300.php
 
@@ -73,15 +73,15 @@ In order for us to consider your result submission official, we need a couple of
 
 1. The notebook that will run the code. The notebook MUST run on on someone else account and the data that it uses should be publically accessible (i.e. if I download the notebook and run it, it must work - so shouldn't be using any private files). If you're wondering how to do this, don't fear! Drop us a line and we will work together to make sure the submission is all good! :)
 
-2. The test sets - in order to replicate this and test against your results, we need saved test sets uploaded separately. 
+2. The test sets - in order to replicate this and test against your results, we need saved test sets uploaded separately.
 
 3. A README.md that describes the (a) the data used - esp important if it's a combination of sources (b) any interesting changes to the model (c) maybe some analysis of some sentences of the final model
 
-4. The model itself. This can be in the form of a google drive or dropbox link. We will be finding a home for our trained models soon. 
+4. The model itself. This can be in the form of a google drive or dropbox link. We will be finding a home for our trained models soon.
 For models to be used for transfer learning, further trained, or deployed, you need to provide:
     1. a checkpoint with the parameters (`.ckpt` file),
     2. the source and target vocabulary (`src_vocab.txt`, `trg_vocab.txt`),
-    3. the configuration file (`config.yaml`), 
+    3. the configuration file (`config.yaml`),
     4. and if applicable: the BPE codes or scripts for your pre-processing pipeline.
 Joey NMT saves the first three in the model directory.
 
@@ -94,7 +94,7 @@ Once you have all of the above, please create a pull request into the repository
 #### Structure of my PR:
 
  Also see this as an example for the structure of your contribution
- 
+
  Structure:
  ```
  /<src-lang>-<tgt-lang>
@@ -115,7 +115,7 @@ Once you have all of the above, please create a pull request into the repository
 Example:
 ```
 /en-xh
-  /xhnavy-data-baseline 
+  /xhnavy-data-baseline
     - notebook.ipynb
     - README.md
     - test.xh
@@ -128,7 +128,7 @@ Example:
     - preprocessing.py
 ```
 
-Here is a link to a pull request that has the relevant things. 
+Here is a link to a pull request that has the relevant things.
 
 **Feeling nervous about contributing your first pull request or unsure how to proceed? Please don't feel discouraged! Drop us an email or a slack message and we will work together to get your contribution in ship shape!**
 

--- a/en-af/jw300-baseline/elan_en_af_masakhane_jw300.ipynb
+++ b/en-af/jw300-baseline/elan_en_af_masakhane_jw300.ipynb
@@ -1,0 +1,1030 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "elan_en_af_masakhane.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Igc5itf-xMGj"
+      },
+      "source": [
+        "# Masakhane - Machine Translation for African Languages (Using JoeyNMT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "x4fXCKCf36IK"
+      },
+      "source": [
+        "## Note before beginning:\n",
+        "### - The idea is that you should be able to make minimal changes to this in order to get SOME result for your own translation corpus. \n",
+        "\n",
+        "### - The tl;dr: Go to the **\"TODO\"** comments which will tell you what to update to get up and running\n",
+        "\n",
+        "### - If you actually want to have a clue what you're doing, read the text and peek at the links\n",
+        "\n",
+        "### - With 100 epochs, it should take around 7 hours to run in Google Colab\n",
+        "\n",
+        "### - Once you've gotten a result for your language, please attach and email your notebook that generated it to masakhanetranslation@gmail.com\n",
+        "\n",
+        "### - If you care enough and get a chance, doing a brief background on your language would be amazing. See examples in  [(Martinus, 2019)](https://arxiv.org/abs/1906.05685)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "l929HimrxS0a"
+      },
+      "source": [
+        "## Retrieve your data & make a parallel corpus\n",
+        "\n",
+        "If you are wanting to use the JW300 data referenced on the Masakhane website or in our GitHub repo, you can use `opus-tools` to convert the data into a convenient format. `opus_read` from that package provides a convenient tool for reading the native aligned XML files and to convert them to TMX format. The tool can also be used to fetch relevant files from OPUS on the fly and to filter the data as necessary. [Read the documentation](https://pypi.org/project/opustools-pkg/) for more details.\n",
+        "\n",
+        "Once you have your corpus files in TMX format (an xml structure which will include the sentences in your target language and your source language in a single file), we recommend reading them into a pandas dataframe. Thankfully, Jade wrote a silly `tmx2dataframe` package which converts your tmx file to a pandas dataframe. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "oGRmDELn7Az0",
+        "outputId": "e4cf5e6a-6683-4011-c4bf-9db4355b1774",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 122
+        }
+      },
+      "source": [
+        "from google.colab import drive\n",
+        "drive.mount('/content/drive')\n",
+        "\n",
+        "# ! echo \"4/sAFT6Lt4k6urQdvj0H6vghJt7kl6X9dCG0gd-XY_1mMDstx7QiAJ0qM\" | python -c \"from google.colab import drive; drive.mount('/content/drive')\""
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Go to this URL in a browser: https://accounts.google.com/o/oauth2/auth?client_id=947318989803-6bn6qk8qdgf4n4g3pfee6491hc0brc4i.apps.googleusercontent.com&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&scope=email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdocs.test%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.photos.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fpeopleapi.readonly&response_type=code\n",
+            "\n",
+            "Enter your authorization code:\n",
+            "··········\n",
+            "Mounted at /content/drive\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "Cn3tgQLzUxwn",
+        "colab": {}
+      },
+      "source": [
+        "# TODO: Set your source and target languages. Keep in mind, these traditionally use language codes as found here:\n",
+        "# These will also become the suffix's of all vocab and corpus files used throughout\n",
+        "import os\n",
+        "source_language = \"en\"\n",
+        "target_language = \"af\"\n",
+        "tag = \"baseline\" # Give a unique name to your folder - this is to ensure you don't rewrite any models you've already submitted\n",
+        "\n",
+        "os.environ[\"src\"] = source_language # Sets them in bash as well, since we often use bash scripts\n",
+        "os.environ[\"tgt\"] = target_language\n",
+        "os.environ[\"tag\"] = tag\n",
+        "\n",
+        "# This will save it to a folder in our gdrive instead!\n",
+        "gdrive_path = \"/content/drive/My Drive/masakhane/%s-%s-%s\" % (source_language, target_language, tag)\n",
+        "os.environ[\"gdrive_path\"] = gdrive_path\n",
+        "!mkdir -p \"$gdrive_path\"\n",
+        "# !mkdir -p \"/content/drive/My Drive/masakhane/$src-$tgt-$tag\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "kBSgJHEw7Nvx",
+        "outputId": "ab1167ec-3654-4667-af5a-57f4ed16aca5",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "source": [
+        "!echo $gdrive_path\n",
+        "# !ls $gdrive_path"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/content/drive/My Drive/masakhane/en-af-baseline\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "gA75Fs9ys8Y9",
+        "outputId": "ab59d363-609c-4a36-b3aa-e9e0f5de80e4",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 102
+        }
+      },
+      "source": [
+        "# Install opus-tools\n",
+        "! pip install opustools-pkg"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting opustools-pkg\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/05/e7/005433050cf3d76bca0fbbc59631ce493fdabb029bbd795a08f26003a6bd/opustools_pkg-0.0.50-py3-none-any.whl (49kB)\n",
+            "\r\u001b[K     |██████▋                         | 10kB 17.4MB/s eta 0:00:01\r\u001b[K     |█████████████▏                  | 20kB 1.8MB/s eta 0:00:01\r\u001b[K     |███████████████████▉            | 30kB 2.6MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▍     | 40kB 1.7MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 51kB 2.0MB/s \n",
+            "\u001b[?25hInstalling collected packages: opustools-pkg\n",
+            "Successfully installed opustools-pkg-0.0.50\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "xq-tDZVks7ZD",
+        "outputId": "1b6f3ba5-a887-4753-d0f7-630a5cd75b20",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "source": [
+        "# change working directory\n",
+        "os.chdir(gdrive_path)\n",
+        "\n",
+        "# Download our corpus\n",
+        "! if ! (( test -f jw300.$src ) && ( test -f jw300.$tgt )); then opus_read -d JW300 -s $src -t $tgt -wm moses -w jw300.$src jw300.$tgt -q; else echo \"Opus files are already present, skipping download.\"; fi\n",
+        "\n",
+        "# extract the corpus file\n",
+        "! if test -f JW300_latest_xml_$src-$tgt.xml.gz; then gunzip JW300_latest_xml_$src-$tgt.xml.gz; elif test -f JW300_latest_xml_$tgt-$src.xml.gz; then gunzip JW300_latest_xml_$tgt-$src.xml.gz; else echo \"ERROR: missing corpus file!\"; fi"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Opus files are already present, skipping download.\n",
+            "ERROR: missing corpus file!\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "3CNdwLBCfSIl",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 142
+        },
+        "outputId": "a442231a-8f44-4d68-98bb-f7fb9cd98c5b"
+      },
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "# TMX file to dataframe\n",
+        "source_file = 'jw300.' + source_language\n",
+        "target_file = 'jw300.' + target_language\n",
+        "\n",
+        "source = []\n",
+        "target = []\n",
+        "with open(source_file) as f:\n",
+        "  for _, line in enumerate(f):\n",
+        "    source.append(line)\n",
+        "with open(target_file) as f:\n",
+        "  for _, line in enumerate(f):\n",
+        "    target.append(line)\n",
+        "\n",
+        "df = pd.DataFrame(zip(source, target), columns=['source_sentence', 'target_sentence'])\n",
+        "df.head(3)"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>source_sentence</th>\n",
+              "      <th>target_sentence</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>‘ They Lifted Me Out of Deep Depression ’\\n</td>\n",
+              "      <td>‘ Hulle het my uit diep depressie gehelp ’\\n</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>A woman from England wrote :\\n</td>\n",
+              "      <td>’ n Vrou van Engeland het geskryf :\\n</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>“ Dear Sir :\\n</td>\n",
+              "      <td>“ Geagte Meneer :\\n</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                               source_sentence                               target_sentence\n",
+              "0  ‘ They Lifted Me Out of Deep Depression ’\\n  ‘ Hulle het my uit diep depressie gehelp ’\\n\n",
+              "1               A woman from England wrote :\\n         ’ n Vrou van Engeland het geskryf :\\n\n",
+              "2                               “ Dear Sir :\\n                           “ Geagte Meneer :\\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 6
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "YkuK3B4p2AkN"
+      },
+      "source": [
+        "## Pre-processing and export\n",
+        "\n",
+        "It is generally a good idea to remove duplicate translations and conflicting translations from the corpus. In practice, these public corpora include some number of these that need to be cleaned.\n",
+        "\n",
+        "In addition we will split our data into dev/test/train and export to the filesystem."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "M_2ouEOH1_1q",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 187
+        },
+        "outputId": "9606b898-616a-4c0b-eeb3-658828253a73"
+      },
+      "source": [
+        "# drop duplicate translations\n",
+        "df_pp = df.drop_duplicates()\n",
+        "\n",
+        "# drop conflicting translations\n",
+        "df_pp.drop_duplicates(subset='source_sentence', inplace=True)\n",
+        "df_pp.drop_duplicates(subset='target_sentence', inplace=True)"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:4: SettingWithCopyWarning: \n",
+            "A value is trying to be set on a copy of a slice from a DataFrame\n",
+            "\n",
+            "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+            "  after removing the cwd from sys.path.\n",
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:5: SettingWithCopyWarning: \n",
+            "A value is trying to be set on a copy of a slice from a DataFrame\n",
+            "\n",
+            "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+            "  \"\"\"\n"
+          ],
+          "name": "stderr"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "hxxBOCA-xXhy",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 221
+        },
+        "outputId": "7b4a4141-be14-4c89-9e81-627b6d164717"
+      },
+      "source": [
+        "# This section does the split between train/test/dev for the parallel corpora then saves them as separate files\n",
+        "# We use 1000 dev test and 1000 test set. In practice, it's useful to use an external test set\n",
+        "\n",
+        "# Do the split between dev/test/train and create parallel corpora\n",
+        "num_dev_patterns = 1000\n",
+        "num_test_patterns = 1000\n",
+        "\n",
+        "# Lower case the corpora\n",
+        "df_pp[\"source_sentence\"] = df_pp[\"source_sentence\"].str.lower()\n",
+        "df_pp[\"target_sentence\"] = df_pp[\"target_sentence\"].str.lower()\n",
+        "\n",
+        "devtest = df_pp.tail(num_dev_patterns + num_test_patterns)\n",
+        "test = devtest.tail(num_test_patterns) # Herman\n",
+        "dev = devtest.head(num_dev_patterns)  # Herman: Error in original\n",
+        "stripped = df_pp.drop(df_pp.tail(num_dev_patterns + num_test_patterns).index)\n",
+        "\n",
+        "stripped[[\"source_sentence\"]].to_csv(\"train.en\", index=False)\n",
+        "stripped[[\"target_sentence\"]].to_csv(\"train.af\", index=False)\n",
+        "\n",
+        "dev[[\"source_sentence\"]].to_csv(\"dev.en\", index=False)\n",
+        "dev[[\"target_sentence\"]].to_csv(\"dev.af\", index=False)\n",
+        "\n",
+        "test[[\"source_sentence\"]].to_csv(\"test.en\", index=False)\n",
+        "test[[\"target_sentence\"]].to_csv(\"test.af\", index=False)"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:5: SettingWithCopyWarning: \n",
+            "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+            "Try using .loc[row_indexer,col_indexer] = value instead\n",
+            "\n",
+            "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+            "  \"\"\"\n",
+            "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:6: SettingWithCopyWarning: \n",
+            "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+            "Try using .loc[row_indexer,col_indexer] = value instead\n",
+            "\n",
+            "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+            "  \n"
+          ],
+          "name": "stderr"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "epeCydmCyS8X"
+      },
+      "source": [
+        "\n",
+        "\n",
+        "---\n",
+        "\n",
+        "\n",
+        "## Installation of JoeyNMT\n",
+        "\n",
+        "JoeyNMT is a simple, minimalist NMT package which is useful for learning and teaching. Check out the documentation for JoeyNMT [here](https://joeynmt.readthedocs.io)  "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "iBRMm4kMxZ8L",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "6fc6dbc6-99a3-4ac2-f3b4-eb4e543954c0"
+      },
+      "source": [
+        "# Install JoeyNMT\n",
+        "! git clone https://github.com/joeynmt/joeynmt.git\n",
+        "\n",
+        "# swap to branch that has the \"ElanScheduler\"! and install that :D\n",
+        "# ! cd joeynmt; git checkout scheduler; git pull --all; pip3 install . # pip install --upgrade --force-reinstall --no-deps <package>\n",
+        "! cd joeynmt; git checkout symlink; git pull --all; pip3 install . # pip install --upgrade --force-reinstall --no-deps <package>\n",
+        "\n",
+        "# perform default installation\n",
+        "# ! cd joeynmt; git checkout master; git pull --all; pip3 install ."
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "fatal: destination path 'joeynmt' already exists and is not an empty directory.\n",
+            "M\tscripts/generate_copy_task.py\n",
+            "M\tscripts/generate_reverse_task.py\n",
+            "M\tscripts/get_iwslt14_bpe.sh\n",
+            "M\tscripts/get_iwslt15_envi.sh\n",
+            "M\tscripts/plot_validations.py\n",
+            "Already on 'symlink'\n",
+            "Your branch is up to date with 'origin/symlink'.\n",
+            "Fetching origin\n",
+            "Already up to date.\n",
+            "Processing /content/drive/My Drive/masakhane/en-af-baseline/joeynmt\n",
+            "Requirement already satisfied: future in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (0.16.0)\n",
+            "Requirement already satisfied: pillow in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (4.3.0)\n",
+            "Requirement already satisfied: numpy<2.0,>=1.14.5 in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (1.16.5)\n",
+            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (41.2.0)\n",
+            "Requirement already satisfied: torch>=1.1 in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (1.2.0)\n",
+            "Requirement already satisfied: tensorflow>=1.14 in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (1.15.0rc3)\n",
+            "Requirement already satisfied: torchtext in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (0.3.1)\n",
+            "Collecting sacrebleu>=1.3.6 (from joeynmt==0.0.1)\n",
+            "  Downloading https://files.pythonhosted.org/packages/0e/e5/93d252182f7cbd4b59bb3ec5797e2ce33cfd6f5aadaf327db170cf4b7887/sacrebleu-1.4.2-py3-none-any.whl\n",
+            "Collecting subword-nmt (from joeynmt==0.0.1)\n",
+            "  Downloading https://files.pythonhosted.org/packages/26/08/58267cb3ac00f5f895457777ed9e0d106dbb5e6388fa7923d8663b04b849/subword_nmt-0.3.6-py2.py3-none-any.whl\n",
+            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (3.0.3)\n",
+            "Requirement already satisfied: seaborn in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (0.9.0)\n",
+            "Collecting pyyaml>=5.1 (from joeynmt==0.0.1)\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e3/e8/b3212641ee2718d556df0f23f78de8303f068fe29cdaa7a91018849582fe/PyYAML-5.1.2.tar.gz (265kB)\n",
+            "\u001b[K     |████████████████████████████████| 266kB 7.5MB/s \n",
+            "\u001b[?25hCollecting pylint (from joeynmt==0.0.1)\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/ef/ed/1cb8e7b85a31807aa0bff8b3e60935370bed7e141df8b530aac6352bddff/pylint-2.4.2-py3-none-any.whl (302kB)\n",
+            "\u001b[K     |████████████████████████████████| 307kB 39.8MB/s \n",
+            "\u001b[?25hRequirement already satisfied: six>=1.12 in /usr/local/lib/python3.6/dist-packages (from joeynmt==0.0.1) (1.12.0)\n",
+            "Requirement already satisfied: olefile in /usr/local/lib/python3.6/dist-packages (from pillow->joeynmt==0.0.1) (0.46)\n",
+            "Requirement already satisfied: wrapt>=1.11.1 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.11.2)\n",
+            "Requirement already satisfied: gast==0.2.2 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (0.2.2)\n",
+            "Requirement already satisfied: absl-py>=0.7.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (0.8.0)\n",
+            "Requirement already satisfied: grpcio>=1.8.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.15.0)\n",
+            "Requirement already satisfied: protobuf>=3.6.1 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (3.7.1)\n",
+            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.1.0)\n",
+            "Requirement already satisfied: keras-applications>=1.0.8 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.0.8)\n",
+            "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (3.1.0)\n",
+            "Requirement already satisfied: tensorflow-estimator==1.15.1 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.15.1)\n",
+            "Requirement already satisfied: tensorboard<1.16.0,>=1.15.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.15.0)\n",
+            "Requirement already satisfied: wheel>=0.26 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (0.33.6)\n",
+            "Requirement already satisfied: astor>=0.6.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (0.8.0)\n",
+            "Requirement already satisfied: keras-preprocessing>=1.0.5 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (1.1.0)\n",
+            "Requirement already satisfied: google-pasta>=0.1.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow>=1.14->joeynmt==0.0.1) (0.1.7)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.6/dist-packages (from torchtext->joeynmt==0.0.1) (2.21.0)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.6/dist-packages (from torchtext->joeynmt==0.0.1) (4.28.1)\n",
+            "Collecting portalocker (from sacrebleu>=1.3.6->joeynmt==0.0.1)\n",
+            "  Downloading https://files.pythonhosted.org/packages/60/ec/836a494dbaa72541f691ec4e66f29fdc8db9bcc7f49e1c2d457ba13ced42/portalocker-1.5.1-py2.py3-none-any.whl\n",
+            "Collecting typing (from sacrebleu>=1.3.6->joeynmt==0.0.1)\n",
+            "  Downloading https://files.pythonhosted.org/packages/fe/2e/b480ee1b75e6d17d2993738670e75c1feeb9ff7f64452153cf018051cc92/typing-3.7.4.1-py3-none-any.whl\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->joeynmt==0.0.1) (1.1.0)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.6/dist-packages (from matplotlib->joeynmt==0.0.1) (0.10.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->joeynmt==0.0.1) (2.5.3)\n",
+            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.6/dist-packages (from matplotlib->joeynmt==0.0.1) (2.4.2)\n",
+            "Requirement already satisfied: scipy>=0.14.0 in /usr/local/lib/python3.6/dist-packages (from seaborn->joeynmt==0.0.1) (1.3.1)\n",
+            "Requirement already satisfied: pandas>=0.15.2 in /usr/local/lib/python3.6/dist-packages (from seaborn->joeynmt==0.0.1) (0.24.2)\n",
+            "Collecting isort<5,>=4.2.5 (from pylint->joeynmt==0.0.1)\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e5/b0/c121fd1fa3419ea9bfd55c7f9c4fedfec5143208d8c7ad3ce3db6c623c21/isort-4.3.21-py2.py3-none-any.whl (42kB)\n",
+            "\u001b[K     |████████████████████████████████| 51kB 21.8MB/s \n",
+            "\u001b[?25hCollecting mccabe<0.7,>=0.6 (from pylint->joeynmt==0.0.1)\n",
+            "  Downloading https://files.pythonhosted.org/packages/87/89/479dc97e18549e21354893e4ee4ef36db1d237534982482c3681ee6e7b57/mccabe-0.6.1-py2.py3-none-any.whl\n",
+            "Collecting astroid<2.4,>=2.3.0 (from pylint->joeynmt==0.0.1)\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/13/e1/74a63c85c501c29c52da5be604c025e368f4dd77daf1fa13c878a33e5a36/astroid-2.3.1-py3-none-any.whl (205kB)\n",
+            "\u001b[K     |████████████████████████████████| 215kB 41.4MB/s \n",
+            "\u001b[?25hRequirement already satisfied: h5py in /usr/local/lib/python3.6/dist-packages (from keras-applications>=1.0.8->tensorflow>=1.14->joeynmt==0.0.1) (2.8.0)\n",
+            "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.6/dist-packages (from tensorboard<1.16.0,>=1.15.0->tensorflow>=1.14->joeynmt==0.0.1) (0.16.0)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.6/dist-packages (from tensorboard<1.16.0,>=1.15.0->tensorflow>=1.14->joeynmt==0.0.1) (3.1.1)\n",
+            "Requirement already satisfied: idna<2.9,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests->torchtext->joeynmt==0.0.1) (2.8)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests->torchtext->joeynmt==0.0.1) (2019.9.11)\n",
+            "Requirement already satisfied: urllib3<1.25,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests->torchtext->joeynmt==0.0.1) (1.24.3)\n",
+            "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests->torchtext->joeynmt==0.0.1) (3.0.4)\n",
+            "Requirement already satisfied: pytz>=2011k in /usr/local/lib/python3.6/dist-packages (from pandas>=0.15.2->seaborn->joeynmt==0.0.1) (2018.9)\n",
+            "Collecting typed-ast<1.5,>=1.4.0; implementation_name == \"cpython\" and python_version < \"3.8\" (from astroid<2.4,>=2.3.0->pylint->joeynmt==0.0.1)\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/31/d3/9d1802c161626d0278bafb1ffb32f76b9d01e123881bbf9d91e8ccf28e18/typed_ast-1.4.0-cp36-cp36m-manylinux1_x86_64.whl (736kB)\n",
+            "\u001b[K     |████████████████████████████████| 737kB 41.6MB/s \n",
+            "\u001b[?25hCollecting lazy-object-proxy==1.4.* (from astroid<2.4,>=2.3.0->pylint->joeynmt==0.0.1)\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/0e/26/534a6d32572a9dbca11619321535c0a7ab34688545d9d67c2c204b9e3a3d/lazy_object_proxy-1.4.2-cp36-cp36m-manylinux1_x86_64.whl (49kB)\n",
+            "\u001b[K     |████████████████████████████████| 51kB 13.9MB/s \n",
+            "\u001b[?25hBuilding wheels for collected packages: joeynmt, pyyaml\n",
+            "  Building wheel for joeynmt (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for joeynmt: filename=joeynmt-0.0.1-cp36-none-any.whl size=69462 sha256=2eb100ac13e868b7e68943631f0ba842d5d081a3f1dee88932c5fd0189fd4217\n",
+            "  Stored in directory: /tmp/pip-ephem-wheel-cache-8heq9clf/wheels/4c/ba/65/529ea2efaa773ebbedd9df75a20586f3366c4efa375e38c09c\n",
+            "  Building wheel for pyyaml (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for pyyaml: filename=PyYAML-5.1.2-cp36-cp36m-linux_x86_64.whl size=44104 sha256=e97131de73fdca9b5d0c399df8ab27c8ccfaababae68ad7562d7cdb481e12cce\n",
+            "  Stored in directory: /root/.cache/pip/wheels/d9/45/dd/65f0b38450c47cf7e5312883deb97d065e030c5cca0a365030\n",
+            "Successfully built joeynmt pyyaml\n",
+            "Installing collected packages: portalocker, typing, sacrebleu, subword-nmt, pyyaml, isort, mccabe, typed-ast, lazy-object-proxy, astroid, pylint, joeynmt\n",
+            "  Found existing installation: PyYAML 3.13\n",
+            "    Uninstalling PyYAML-3.13:\n",
+            "      Successfully uninstalled PyYAML-3.13\n",
+            "Successfully installed astroid-2.3.1 isort-4.3.21 joeynmt-0.0.1 lazy-object-proxy-1.4.2 mccabe-0.6.1 portalocker-1.5.1 pylint-2.4.2 pyyaml-5.1.2 sacrebleu-1.4.2 subword-nmt-0.3.6 typed-ast-1.4.0 typing-3.7.4.1\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "AaE77Tcppex9"
+      },
+      "source": [
+        "# Preprocessing the Data into Subword BPE Tokens\n",
+        "\n",
+        "- One of the most powerful improvements for agglutinative languages (a feature of most Bantu languages) is using BPE tokenization [ (Sennrich, 2015) ](https://arxiv.org/abs/1508.07909).\n",
+        "\n",
+        "- It was also shown that by optimizing the umber of BPE codes we significantly improve results for low-resourced languages [(Sennrich, 2019)](https://www.aclweb.org/anthology/P19-1021) [(Martinus, 2019)](https://arxiv.org/abs/1906.05685)\n",
+        "\n",
+        "- Below we have the scripts for doing BPE tokenization of our data. We use 4000 tokens as recommended by [(Sennrich, 2019)](https://www.aclweb.org/anthology/P19-1021). You do not need to change anything. Simply running the below will be suitable. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "H-TyjtmXB1mL",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 561
+        },
+        "outputId": "fe8692cb-96d2-4a5f-dc36-48d2607bbbf7"
+      },
+      "source": [
+        "# One of the huge boosts in NMT performance was to use a different method of tokenizing. \n",
+        "# Usually, NMT would tokenize by words. However, using a method called BPE gave amazing boosts to performance\n",
+        "\n",
+        "# Do subword NMT\n",
+        "# from os import path\n",
+        "\n",
+        "os.environ[\"data_path\"] = path.join(\"joeynmt\", \"data\", source_language + target_language) # Herman!\n",
+        "\n",
+        "! if ! (( test -f vocab.$src ) && ( test -f vocab.$tgt )); then subword-nmt learn-joint-bpe-and-vocab --input train.$src train.$tgt -s 4000 -o bpe.codes.4000 --write-vocabulary vocab.$src vocab.$tgt; else echo \"BPE vocab files already present...\"; fi\n",
+        "\n",
+        "! if ! test -f train.bpe.$src; then subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$src < train.$src > train.bpe.$src; else echo \"train.bpe.$src already present...\"; fi\n",
+        "! if ! test -f train.bpe.$tgt; then subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$tgt < train.$tgt > train.bpe.$tgt; else echo \"train.bpe.$tgt already present...\"; fi\n",
+        "\n",
+        "! if ! test -f dev.bpe.$src; then subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$src < dev.$src > dev.bpe.$src; else echo \"dev.bpe.$src already present...\"; fi\n",
+        "! if ! test -f dev.bpe.$tgt; then subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$tgt < dev.$tgt > dev.bpe.$tgt; else echo \"dev.bpe.$tgt already present...\"; fi\n",
+        "\n",
+        "! if ! test -f test.bpe.$src; then subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$src < test.$src > test.bpe.$src; else echo \"test.bpe.$src already present...\"; fi\n",
+        "! if ! test -f test.bpe.$tgt; then subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$tgt < test.$tgt > test.bpe.$tgt; else echo \"test.bpe.$tgt already present...\"; fi\n",
+        "\n",
+        "# Create directory, move everyone we care about to the correct location\n",
+        "! mkdir -p $data_path\n",
+        "! if ! test $(ls -l $data_path | grep train | wc -l) -gt 0; then cp train.* $data_path; else echo \"train files already in data directory...\"; fi\n",
+        "! if ! test $(ls -l $data_path | grep test | wc -l) -gt 0; then cp test.* $data_path; else echo \"test files already in data directory...\"; fi\n",
+        "! if ! test $(ls -l $data_path | grep dev | wc -l) -gt 0; then cp dev.* $data_path; else echo \"dev files already in data directory...\"; fi\n",
+        "! if ! test -f $data_path/bpe.codes.4000; then cp bpe.codes.4000 $data_path ; else echo \"bpe.codes.4000 already in data directory...\"; fi\n",
+        "! ls $data_path\n",
+        "\n",
+        "# Create that vocab using build_vocab\n",
+        "! sudo chmod 777 joeynmt/scripts/build_vocab.py\n",
+        "! if ! test -f joeynmt/data/$src$tgt/vocab.txt; then joeynmt/scripts/build_vocab.py joeynmt/data/$src$tgt/train.bpe.$src joeynmt/data/$src$tgt/train.bpe.$tgt --output_path joeynmt/data/$src$tgt/vocab.txt ; else echo \"vocab.txt already in data directory...\"; fi\n",
+        "\n",
+        "# Some output\n",
+        "! echo \"BPE Afrikaans Sentences\"\n",
+        "! tail -n 5 test.bpe.$tgt\n",
+        "! echo \"Combined BPE Vocab\"\n",
+        "! tail -n 10 joeynmt/data/$src$tgt/vocab.txt"
+      ],
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "BPE vocab files already present...\n",
+            "train.bpe.en already present...\n",
+            "train.bpe.af already present...\n",
+            "dev.bpe.en already present...\n",
+            "dev.bpe.af already present...\n",
+            "test.bpe.en already present...\n",
+            "test.bpe.af already present...\n",
+            "train files already in data directory...\n",
+            "test files already in data directory...\n",
+            "dev files already in data directory...\n",
+            "bpe.codes.4000 already in data directory...\n",
+            "bpe.codes.4000\tdev.bpe.en  test.bpe.af  train.af      train.en\n",
+            "dev.af\t\tdev.en\t    test.bpe.en  train.bpe.af  vocab.txt\n",
+            "dev.bpe.af\ttest.af     test.en\t train.bpe.en\n",
+            "vocab.txt already in data directory...\n",
+            "BPE Afrikaans Sentences\n",
+            "\"\n",
+            "\"maar ons kan daarvan seker wees dat ons eer@@ likheid en ander goeie eienskappe vir ons hemelse vader baie ko@@ sb@@ aar@@ der is as enige ed@@ el@@ ste@@ en !\n",
+            "\"\n",
+            "\"as ons eer@@ lik is , het ons ’ n sk@@ oon gewe@@ te en vryheid van spraak in die bediening\n",
+            "\"\n",
+            "Combined BPE Vocab\n",
+            "·@@\n",
+            "̣@@\n",
+            "̈@@\n",
+            "§\n",
+            "ז@@\n",
+            "inst\n",
+            "˜\n",
+            ";@@\n",
+            "ḥ\n",
+            "saja\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Ixmzi60WsUZ8"
+      },
+      "source": [
+        "# Creating the JoeyNMT Config\n",
+        "\n",
+        "JoeyNMT requires a yaml config. We provide a template below. We've also set a number of defaults with it, that you may play with!\n",
+        "\n",
+        "- We used Transformer architecture \n",
+        "- We set our dropout to reasonably high: 0.3 (recommended in  [(Sennrich, 2019)](https://www.aclweb.org/anthology/P19-1021))\n",
+        "\n",
+        "Things worth playing with:\n",
+        "- The batch size (also recommended to change for low-resourced languages)\n",
+        "- The number of epochs (we've set it at 30 just so it runs in about an hour, for testing purposes)\n",
+        "- The decoder options (beam_size, alpha)\n",
+        "- Evaluation metrics (BLEU versus Crhf4)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "PIs1lY2hxMsl",
+        "colab": {}
+      },
+      "source": [
+        "# # This creates the config file for our JoeyNMT system. It might seem overwhelming so we've provided a couple of useful parameters you'll need to update\n",
+        "# # (You can of course play with all the parameters if you'd like!)\n",
+        "\n",
+        "# name = '%s%s' % (source_language, target_language)\n",
+        "# gdrive_path = os.environ[\"gdrive_path\"]\n",
+        "\n",
+        "# # Create the config\n",
+        "# config = \"\"\"\n",
+        "# name: \"{name}_transformer\"\n",
+        "\n",
+        "# data:\n",
+        "#     src: \"{source_language}\"\n",
+        "#     trg: \"{target_language}\"\n",
+        "#     train: \"data/{name}/train.bpe\"\n",
+        "#     dev:   \"data/{name}/dev.bpe\"\n",
+        "#     test:  \"data/{name}/test.bpe\"\n",
+        "#     level: \"bpe\"\n",
+        "#     lowercase: False\n",
+        "#     max_sent_length: 100\n",
+        "#     src_vocab: \"data/{name}/vocab.txt\"\n",
+        "#     trg_vocab: \"data/{name}/vocab.txt\"\n",
+        "\n",
+        "# testing:\n",
+        "#     beam_size: 5\n",
+        "#     alpha: 1.0\n",
+        "\n",
+        "# training:\n",
+        "#     #load_model: \"{gdrive_path}/models/{name}_transformer/1.ckpt\" # if uncommented, load a pre-trained model from this checkpoint\n",
+        "#     random_seed: 42\n",
+        "#     optimizer: \"adam\"\n",
+        "#     normalization: \"tokens\"\n",
+        "#     adam_betas: [0.9, 0.999] \n",
+        "#     scheduling: \"elan\"            # Try switching to Elan scheduling\n",
+        "#     learning_rate_decay_length: 5000 # number of steps to reduce by the decay factor for Elan method\n",
+        "#     learning_rate_peak: 0.002  # peak for Elan scheduler (default: 1)\n",
+        "#     learning_rate_warmup: 2000  # warmup steps for Elan scheduler\n",
+        "#     learning_rate_factor: 0.5       # factor for Noam scheduler (used with Transformer)\n",
+        "#     learning_rate_warmup: 1000      # warmup steps for Noam scheduler (used with Transformer)\n",
+        "#     patience: 8\n",
+        "#     decrease_factor: 0.7\n",
+        "#     loss: \"crossentropy\"\n",
+        "#     learning_rate: 0.0002\n",
+        "#     learning_rate_min: 0.00000001\n",
+        "#     weight_decay: 0.0\n",
+        "#     label_smoothing: 0.1\n",
+        "#     batch_size: 4096\n",
+        "#     batch_type: \"token\"\n",
+        "#     eval_batch_size: 3600\n",
+        "#     eval_batch_type: \"token\"\n",
+        "#     batch_multiplier: 1\n",
+        "#     early_stopping_metric: \"ppl\"\n",
+        "#     epochs: 30 # TODO: Decrease for when playing around and checking of working. Around 30 is sufficient to check if its working at all\n",
+        "#     validation_freq: 500 # 4000 # Decrease this for testing\n",
+        "#     logging_freq: 100\n",
+        "#     eval_metric: \"bleu\"\n",
+        "#     model_dir: \"models/{name}_transformer\"\n",
+        "#     overwrite: True\n",
+        "#     shuffle: True\n",
+        "#     use_cuda: True\n",
+        "#     max_output_length: 100\n",
+        "#     print_valid_sents: [0, 1, 2, 3]\n",
+        "#     keep_last_ckpts: 3\n",
+        "\n",
+        "# model:\n",
+        "#     initializer: \"xavier\"\n",
+        "#     bias_initializer: \"zeros\"\n",
+        "#     init_gain: 1.0\n",
+        "#     embed_initializer: \"xavier\"\n",
+        "#     embed_init_gain: 1.0\n",
+        "#     tied_embeddings: True\n",
+        "#     tied_softmax: True\n",
+        "#     encoder:\n",
+        "#         type: \"transformer\"\n",
+        "#         num_layers: 3\n",
+        "#         num_heads: 8\n",
+        "#         embeddings:\n",
+        "#             embedding_dim: 512\n",
+        "#             scale: True\n",
+        "#             dropout: 0.\n",
+        "#         # typically ff_size = 4 x hidden_size\n",
+        "#         hidden_size: 512\n",
+        "#         ff_size: 2048\n",
+        "#         dropout: 0.3\n",
+        "#     decoder:\n",
+        "#         type: \"transformer\"\n",
+        "#         num_layers: 3\n",
+        "#         num_heads: 8\n",
+        "#         embeddings:\n",
+        "#             embedding_dim: 512\n",
+        "#             scale: True\n",
+        "#             dropout: 0.\n",
+        "#         # typically ff_size = 4 x hidden_size\n",
+        "#         hidden_size: 512\n",
+        "#         ff_size: 2048\n",
+        "#         dropout: 0.25\n",
+        "# \"\"\".format(name=name, gdrive_path=os.environ[\"gdrive_path\"], source_language=source_language, target_language=target_language)\n",
+        "# with open(\"joeynmt/configs/transformer_{name}.yaml\".format(name=name),'w') as f:\n",
+        "#     f.write(config)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "luNmAL42JDd7",
+        "colab": {}
+      },
+      "source": [
+        "# This creates the config file for our JoeyNMT system. It might seem overwhelming so we've provided a couple of useful parameters you'll need to update\n",
+        "# (You can of course play with all the parameters if you'd like!)\n",
+        "\n",
+        "name = '%s%s' % (source_language, target_language)\n",
+        "gdrive_path = os.environ[\"gdrive_path\"]\n",
+        "\n",
+        "# Create the config\n",
+        "config = \"\"\"\n",
+        "name: \"{name}_transformer\"\n",
+        "\n",
+        "data:\n",
+        "    src: \"{source_language}\"\n",
+        "    trg: \"{target_language}\"\n",
+        "    train: \"data/{name}/train.bpe\"\n",
+        "    dev:   \"data/{name}/dev.bpe\"\n",
+        "    test:  \"data/{name}/test.bpe\"\n",
+        "    level: \"bpe\"\n",
+        "    lowercase: False\n",
+        "    max_sent_length: 100\n",
+        "    src_vocab: \"data/{name}/vocab.txt\"\n",
+        "    trg_vocab: \"data/{name}/vocab.txt\"\n",
+        "\n",
+        "testing:\n",
+        "    beam_size: 5\n",
+        "    alpha: 1.0\n",
+        "\n",
+        "training:\n",
+        "    #load_model: \"{gdrive_path}/models/{name}_transformer/1.ckpt\" # if uncommented, load a pre-trained model from this checkpoint\n",
+        "    #load_model: \"{gdrive_path}/joeynmt/models/{name}_transformer/3500.ckpt\" # if uncommented, load a pre-trained model from this checkpoint\n",
+        "    load_model: \"{gdrive_path}/Backup_models/Copy of best.ckpt\" # if uncommented, load a pre-trained model from this checkpoint\n",
+        "    random_seed: 42\n",
+        "    optimizer: \"adam\"\n",
+        "    normalization: \"tokens\"\n",
+        "    adam_betas: [0.9, 0.999] \n",
+        "    scheduling: \"noam\"            # Try switching to Elan scheduling\n",
+        "    learning_rate_decay_length: 5000 # number of steps to reduce by the decay factor for Elan method\n",
+        "    learning_rate_peak: 0.002  # peak for Elan scheduler (default: 1)\n",
+        "    learning_rate_warmup: 2000  # warmup steps for Elan scheduler\n",
+        "    learning_rate_factor: 1       # factor for Noam scheduler (used with Transformer)\n",
+        "    learning_rate_warmup: 1000      # warmup steps for Noam scheduler (used with Transformer)\n",
+        "    patience: 8\n",
+        "    decrease_factor: 0.7\n",
+        "    loss: \"crossentropy\"\n",
+        "    learning_rate: 0.0002\n",
+        "    learning_rate_min: 0.00000001\n",
+        "    weight_decay: 0.0\n",
+        "    label_smoothing: 0.1\n",
+        "    batch_size: 4096\n",
+        "    batch_type: \"token\"\n",
+        "    eval_batch_size: 3600\n",
+        "    eval_batch_type: \"token\"\n",
+        "    batch_multiplier: 1\n",
+        "    early_stopping_metric: \"ppl\"\n",
+        "    epochs: 30 # TODO: Decrease for when playing around and checking of working. Around 30 is sufficient to check if its working at all\n",
+        "    validation_freq: 500 # 4000 # Decrease this for testing\n",
+        "    logging_freq: 100\n",
+        "    eval_metric: \"bleu\"\n",
+        "    model_dir: \"models/{name}_transformer\"\n",
+        "    overwrite: True\n",
+        "    shuffle: True\n",
+        "    use_cuda: True\n",
+        "    max_output_length: 100\n",
+        "    print_valid_sents: [0, 1, 2, 3]\n",
+        "    keep_last_ckpts: 3\n",
+        "\n",
+        "model:\n",
+        "    initializer: \"xavier\"\n",
+        "    bias_initializer: \"zeros\"\n",
+        "    init_gain: 1.0\n",
+        "    embed_initializer: \"xavier\"\n",
+        "    embed_init_gain: 1.0\n",
+        "    tied_embeddings: True\n",
+        "    tied_softmax: True\n",
+        "    encoder:\n",
+        "        type: \"transformer\"\n",
+        "        num_layers: 3\n",
+        "        num_heads: 8\n",
+        "        embeddings:\n",
+        "            embedding_dim: 512\n",
+        "            scale: True\n",
+        "            dropout: 0.\n",
+        "        # typically ff_size = 4 x hidden_size\n",
+        "        hidden_size: 512\n",
+        "        ff_size: 2048\n",
+        "        dropout: 0.3\n",
+        "    decoder:\n",
+        "        type: \"transformer\"\n",
+        "        num_layers: 3\n",
+        "        num_heads: 8\n",
+        "        embeddings:\n",
+        "            embedding_dim: 512\n",
+        "            scale: True\n",
+        "            dropout: 0.\n",
+        "        # typically ff_size = 4 x hidden_size\n",
+        "        hidden_size: 512\n",
+        "        ff_size: 2048\n",
+        "        dropout: 0.25\n",
+        "\"\"\".format(name=name, gdrive_path=os.environ[\"gdrive_path\"], source_language=source_language, target_language=target_language)\n",
+        "with open(os.path.join(gdrive_path, f\"joeynmt/configs/transformer_{name}.yaml\"),'w') as f:\n",
+        "    f.write(config)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "pIifxE3Qzuvs"
+      },
+      "source": [
+        "# Train the Model\n",
+        "\n",
+        "This single line of joeynmt runs the training using the config we made above"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "6ZBPFwT94WpI",
+        "colab": {}
+      },
+      "source": [
+        "# # Train the model\n",
+        "# # You can press Ctrl-C to stop. And then run the next cell to save your checkpoints! \n",
+        "\n",
+        "# os.chdir(os.path.join(gdrive_path, \"joeynmt\"))\n",
+        "\n",
+        "# ! python3 joeynmt/__main__.py train configs/transformer_$src$tgt.yaml\n",
+        "# # !cd joeynmt; python3 -m joeynmt train configs/transformer_$src$tgt.yaml"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "MBoDS09JM807",
+        "colab": {}
+      },
+      "source": [
+        "# Copy the created models from the notebook storage to google drive for persistant storage \n",
+        "# !cp -r joeynmt/models/${src}${tgt}_transformer/* \"$gdrive_path/models/${src}${tgt}_transformer/\"\n",
+        "! mv \"$gdrive_path/../../masakhane_models_backup/models\" \"$gdrive_path/joeynmt\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "n94wlrCjVc17",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 408
+        },
+        "outputId": "72875a99-fbd7-4518-9d7d-a7deda40f3fc"
+      },
+      "source": [
+        "# Output our validation accuracy\n",
+        "! cat \"$gdrive_path/models/${src}${tgt}_transformer/validations.txt\""
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Steps: 500\tLoss: 90178.07812\tPPL: 37.62176\tbleu: 0.90432\tLR: 0.00069877\t*\n",
+            "Steps: 1000\tLoss: 73574.21094\tPPL: 19.29143\tbleu: 2.83208\tLR: 0.00139754\t*\n",
+            "Steps: 1500\tLoss: 67591.24219\tPPL: 15.16492\tbleu: 4.42870\tLR: 0.00114109\t*\n",
+            "Steps: 2000\tLoss: 63030.15234\tPPL: 12.62282\tbleu: 5.49023\tLR: 0.00098821\t*\n",
+            "Steps: 2500\tLoss: 58729.75781\tPPL: 10.61762\tbleu: 7.85880\tLR: 0.00088388\t*\n",
+            "Steps: 3000\tLoss: 54868.16016\tPPL: 9.09000\tbleu: 10.19263\tLR: 0.00080687\t*\n",
+            "Steps: 3500\tLoss: 51913.49219\tPPL: 8.07133\tbleu: 11.93531\tLR: 0.00074702\t*\n",
+            "Steps: 4000\tLoss: 48699.18750\tPPL: 7.09235\tbleu: 15.10315\tLR: 0.00069877\t*\n",
+            "Steps: 4500\tLoss: 46169.38281\tPPL: 6.40610\tbleu: 17.91368\tLR: 0.00065881\t*\n",
+            "Steps: 5000\tLoss: 43576.91016\tPPL: 5.77168\tbleu: 21.04279\tLR: 0.00062500\t*\n",
+            "Steps: 5500\tLoss: 40994.23438\tPPL: 5.20214\tbleu: 23.94864\tLR: 0.00059591\t*\n",
+            "Steps: 6000\tLoss: 38960.73438\tPPL: 4.79354\tbleu: 26.45850\tLR: 0.00057054\t*\n",
+            "Steps: 6500\tLoss: 36407.32422\tPPL: 4.32561\tbleu: 30.21616\tLR: 0.00054816\t*\n",
+            "Steps: 7000\tLoss: 34931.22266\tPPL: 4.07624\tbleu: 31.84504\tLR: 0.00052822\t*\n",
+            "Steps: 7500\tLoss: 33079.28125\tPPL: 3.78360\tbleu: 34.36116\tLR: 0.00051031\t*\n",
+            "Steps: 8000\tLoss: 31651.22070\tPPL: 3.57237\tbleu: 35.70833\tLR: 0.00049411\t*\n",
+            "Steps: 8500\tLoss: 30685.96289\tPPL: 3.43632\tbleu: 37.68450\tLR: 0.00047935\t*\n",
+            "Steps: 9000\tLoss: 29720.62891\tPPL: 3.30544\tbleu: 38.99970\tLR: 0.00046585\t*\n",
+            "Steps: 9500\tLoss: 28773.71875\tPPL: 3.18189\tbleu: 41.25283\tLR: 0.00045342\t*\n",
+            "Steps: 10000\tLoss: 28502.89258\tPPL: 3.14742\tbleu: 40.88431\tLR: 0.00044194\t*\n",
+            "Steps: 10500\tLoss: 28264.90039\tPPL: 3.11743\tbleu: 41.76735\tLR: 0.00043129\t*\n",
+            "Steps: 11000\tLoss: 27241.58398\tPPL: 2.99171\tbleu: 43.46731\tLR: 0.00042137\t*\n",
+            "Steps: 11500\tLoss: 26806.92188\tPPL: 2.93985\tbleu: 43.37800\tLR: 0.00041211\t*\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "66WhRE9lIhoD",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "c139f283-db05-404d-c239-87d68bb46595"
+      },
+      "source": [
+        "# Test our model\n",
+        "! cd joeynmt; python3 -m joeynmt test \"$gdrive_path/models/${src}${tgt}_transformer/config.yaml\""
+      ],
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "2019-10-16 13:50:44,139 -  dev bleu:  45.10 [Beam search decoding with beam size = 5 and alpha = 1.0]\n",
+            "2019-10-16 13:51:41,319 - test bleu:  45.48 [Beam search decoding with beam size = 5 and alpha = 1.0]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}

--- a/en-af/jw300-baseline/readme.md
+++ b/en-af/jw300-baseline/readme.md
@@ -1,0 +1,22 @@
+# English to Afrikaans
+
+Author: Elan van Biljon
+
+## Data
+
+	- The JW300 English-Afrikaans dataset.
+
+## Model
+
+- Default Masakhane Transformer translation model.
+- [Link to google drive folder with models](https://drive.google.com/drive/folders/1GU683QZ0X22ItilcTtqAxVCd8Oc8s8g-?usp=sharing)
+
+## Analysis
+
+Smaller models perform drastically better due to better signal propagation dynamics.
+
+# Results
+
+ BLEU dev | BLEU test
+ --- | ---
+ 45.10 | 45.48

--- a/en-af/jw300-baseline/results.txt
+++ b/en-af/jw300-baseline/results.txt
@@ -1,0 +1,2 @@
+2019-10-16 13:50:44,139 -  dev bleu:  45.10 [Beam search decoding with beam size = 5 and alpha = 1.0]
+2019-10-16 13:51:41,319 - test bleu:  45.48 [Beam search decoding with beam size = 5 and alpha = 1.0]

--- a/en-af/jw300-baseline/test.af
+++ b/en-af/jw300-baseline/test.af
@@ -1,0 +1,2001 @@
+target_sentence
+"wanneer ons die bybel en ons publikasies lees , moet ons nadink oor hoe die inligting ons persoonlik kan help
+"
+"’ n jong meisie praat met haar skoolmaats oor die goeie nuus en bied vir hulle ’ n traktaat aan .
+"
+"sy woon in die dorp ho in die volta - streek van ghana
+"
+"“ gaan voort om te begryp wat die wil van jehovah is . ” — efesiërs 5 : 17 .
+"
+"liedere : 69 , 57
+"
+"watter uitwerking kan ons besluite op ons en ander hê ?
+"
+"hoe kan ons uitvind wat jehovah sal behaag as die bybel nie ’ n spesifieke wet gee nie ?
+"
+"hoe kan ons jehovah se denke beter leer ken ?
+"
+"watter wette vind ons in die bybel , en hoe vind ons daarby baat as ons dit gehoorsaam ?
+"
+"in die bybel het jehovah ons wette gegee wat duidelik toon wat hy wil hê ons moet doen .
+"
+"hy beveel ons byvoorbeeld om nie te steel , afgode te aanbid , dronk te word of ons aan seksuele onsedelikheid skuldig te maak nie .
+"
+"en jehovah se seun , jesus , het ’ n uitdruklike bevel aan sy volgelinge gegee : “ maak dissipels van mense van al die nasies , en doop hulle in die naam van die vader en van die seun en van die heilige gees , en leer hulle om alles te onderhou wat ek julle beveel het .
+"
+"alles wat jehovah en jesus vir ons sê om te doen , is tot ons beswil .
+"
+"jehovah se wette leer ons hoe om vir onsself en ons gesin te sorg en help ons om beter gesondheid te geniet en om gelukkig te wees .
+"
+"nog belangriker , wanneer ons jehovah se gebooie gehoorsaam , insluitende die gebod om te preek , behaag ons hom en seën hy ons .
+"
+"2 , 3 . ( a ) waarom bevat die bybel nie reëls oor elke situasie in die lewe nie ?
+"
+"maar die bybel bevat nie reëls oor elke situasie in die lewe nie .
+"
+"daar is byvoorbeeld nie spesifieke instruksies in die bybel oor wat ons moet aantrek nie .
+"
+"dit toon hoe wys jehovah is .
+"
+"mense regoor die wêreld dra verskillende style klere , en modes verander gedurig , maar die bybel se standaarde is tydloos .
+"
+"dit bevat ook nie ’ n klomp reëls oor watter soort werk , vermaak of gesondheidsorg ons moet kies nie .
+"
+"jehovah laat individue en gesinshoofde toe om self oor hierdie dinge te besluit .
+"
+"wanneer ons dus ’ n belangrike besluit moet neem wat ’ n groot uitwerking op ons lewe sal hê en ons nie ’ n wet daaroor in die bybel vind nie , wonder ons dalk : ‘ maak dit vir jehovah saak wat ek besluit ?
+"
+"sal hy tevrede wees met my besluit solank ek nie ’ n bybelwet verbreek nie ?
+"
+"hoe kan ek seker wees dat my besluite hom sal behaag ? ’
+"
+"party mense dink dat hulle kan doen net wat hulle wil .
+"
+"maar ons wil doen wat jehovah behaag .
+"
+"voordat ons ’ n besluit neem , moet ons dus nadink oor wat die bybel sê en dit dan gehoorsaam .
+"
+"die bybel sê byvoorbeeld vir ons wat god se wet oor die gebruik van bloed is , en ons gehoorsaam dit .
+"
+"ons kan jehovah in gebed vra om ons te help om besluite te neem wat hom sal behaag .
+"
+"ons besluite het ’ n uitwerking op ons . ’ n goeie besluit kan ons help om nader aan jehovah te kom . ’ n slegte besluit kan ons vriendskap met hom skaad .
+"
+"ons besluite kan ook ander mense raak .
+"
+"ons wil niks doen wat ons broers kan ontstel of hulle geloof kan laat verswak nie .
+"
+"ons wil ook nie die oorsaak wees van probleme tussen broers in die gemeente nie .
+"
+"dit is dus belangrik dat ons goeie besluite neem . — lees romeine 14 : 19 ; galasiërs 6 : 7 .
+"
+"hoe kan ons goeie besluite neem ?
+"
+"hoe kan ons goeie besluite neem wanneer die bybel nie vir ons sê presies wat ons moet doen nie ?
+"
+"ons moenie ons eie kop volg nie ; ons moet eerder goed nadink oor ons situasie en ’ n besluit neem wat jehovah sal behaag .
+"
+"dan kan ons seker wees dat hy ons sal seën . — lees psalm 37 : 5 .
+"
+"hoe kan ons uitvind wat jehovah sal behaag as daar nie ’ n bybelwet is wat ons in ’ n sekere situasie kan help nie ?
+"
+"maar hoe kan ons uitvind wat jehovah sal behaag ?
+"
+"efesiërs 5 : 17 sê vir ons : “ gaan voort om te begryp wat die wil van jehovah is . ”
+"
+"as daar nie ’ n spesifieke bybelwet is wat ons in ’ n sekere situasie kan help nie , moet ons begryp , of verstaan , wat jehovah wil hê ons moet doen .
+"
+"ons moet tot hom bid en toelaat dat sy heilige gees ons lei .
+"
+"hoe het jesus begryp wat jehovah wou hê hy moet doen ?
+"
+"jesus het altyd begryp wat jehovah wou hê hy moet doen .
+"
+"byvoorbeeld , die bybel meld twee geleenthede toe die skares wat jesus gevolg het , honger geword het .
+"
+"jesus het gebid en hulle daarna wonderdadig gevoed . tog het hy geweier om klippe in brode te verander toe hy honger was en deur die duiwel in die wildernis versoek is .
+"
+"( lees matteus 4 : 2 - 4 . )
+"
+"omdat hy sy vader baie goed geken het , het hy geweet dat jehovah nie wou hê dat hy heilige gees moet gebruik om homself te bevoordeel nie .
+"
+"hy was seker dat sy vader hom sou lei en van die nodige voedsel sou voorsien .
+"
+"soos jesus kan ons goeie besluite neem as ons op jehovah se leiding vertrou .
+"
+"slaan ag op hom in al jou weë , en hy sal jou paaie reguit maak .
+"
+"vrees jehovah en wyk af van die kwaad ” .
+"
+"wanneer ons die bybel studeer en jehovah se denke leer ken , sal ons begryp wat hy wil hê ons in ’ n sekere situasie moet doen .
+"
+"en hoe beter ons jehovah se denke leer ken , hoe makliker sal dit vir ons wees om besluite te neem wat hom sal behaag .
+"
+"ja , ons sal meer “ ingestel [ wees ] op god se leiding ” . — esegiël 11 : 19 , voetnoot in nw .
+"
+"stel jou voor dat ’ n getroude vrou ’ n paar mooi skoene sien terwyl sy inkopies doen .
+"
+"maar dit is baie duur .
+"
+"al is haar man nie by haar nie , weet sy hoe hy daaroor sal voel as sy soveel geld uitgee .
+"
+"hoe weet sy dit ?
+"
+"hulle is al ’ n paar jaar getroud , en daarom weet sy hoe hy wil hê hulle hulle geld moet gebruik .
+"
+"net so sal ons , as ons jehovah se denke leer ken en nadink oor wat hy in die verlede gedoen het , weet wat hy in verskillende situasies van ons verwag .
+"
+"watter vrae kan ons ons afvra wanneer ons die bybel lees of studeer ?
+"
+"( sien die venster “ wanneer jy die bybel studeer , moet jy jou afvra ” . )
+"
+"hoe kan ons jehovah se denke leer ken ?
+"
+"ons moet allereers die bybel gereeld lees en studeer .
+"
+"terwyl ons dit doen , kan ons ons afvra : ‘ wat leer dit my omtrent jehovah ?
+"
+"waarom het hy so opgetree ? ’
+"
+"en soos dawid moet ons jehovah vra om ons te help om hom beter te leer ken .
+"
+"dawid het geskryf : “ maak u weë aan my bekend , o jehovah ; leer my u paaie .
+"
+"laat my in u waarheid wandel en leer my , want u is my god van redding .
+"
+"op u het ek die hele dag gehoop ” .
+"
+"wanneer ons iets omtrent jehovah leer , kan ons aan situasies probeer dink waar ons hierdie inligting kan gebruik .
+"
+"kan ons dit in die gesin , by die werk , by die skool of in die bediening gebruik ?
+"
+"as ons aan ’ n spesifieke situasie dink , sal dit makliker wees om te begryp hoe jehovah wil hê ons die inligting moet gebruik .
+"
+"as ons jehovah se denke wil leer ken , moet ons die bybel gereeld lees en studeer
+"
+"hoe kan ons publikasies en die vergaderinge ons help om jehovah se denke oor verskeie sake te leer ken ?
+"
+"nog ’ n manier waarop ons jehovah se denke kan leer ken , is om noukeurig aandag te skenk aan wat sy organisasie ons uit die bybel leer .
+"
+"byvoorbeeld , wanneer ons ’ n besluit moet neem , kan die watch tower publications index en die navorsingsgids vir jehovah se getuies ons help om jehovah se denke oor die saak te kry .
+"
+"ons kan ook baat vind by ons christelike vergaderinge as ons aandagtig luister , kommentaar lewer en nadink oor wat ons leer .
+"
+"dit sal ons help om ons denke in ooreenstemming te bring met jehovah se denke .
+"
+"dan sal ons besluite kan neem wat hom sal behaag en wat hy sal seën .
+"
+"hoe kan ons ’ n wyse besluit neem as ons jehovah se denke in ag neem ? gee ’ n voorbeeld .
+"
+"kom ons kyk na ’ n voorbeeld wat toon hoe ons ’ n wyse besluit kan neem as ons jehovah se denke in ag neem .
+"
+"miskien wil jy pionier .
+"
+"jy het veranderinge in jou lewe aangebring sodat jy meer tyd in die bediening kan deurbring .
+"
+"maar jy is nog nie seker of jy werklik tevrede sal wees met minder geld en besittings nie .
+"
+"die bybel sê natuurlik nie dat ons moet pionier om jehovah te dien nie .
+"
+"ons kan hom ook as verkondigers getrou dien .
+"
+"maar jesus het gesê dat jehovah diegene seën wat opofferings vir die koninkryk maak .
+"
+"( lees lukas 18 : 29 , 30 . )
+"
+"die bybel sê ook dat dit jehovah behaag wanneer ons alles in ons vermoë doen om hom te loof , en hy wil hê dat ons gelukkig moet wees in sy diens .
+"
+"as ons hieroor bid en peins , sal ons ’ n besluit kan neem wat prakties is vir ons situasie en wat deur jehovah geseën sal word .
+"
+"hoe kan jy vasstel of ’ n sekere klerestyl jehovah behaag ?
+"
+"hier is nog ’ n voorbeeld : jy hou baie van ’ n sekere klerestyl , maar jy weet dat party in die gemeente dalk aanstoot sal neem as jy hierdie styl dra .
+"
+"die bybel sê niks oor hierdie spesifieke styl nie .
+"
+"hoe kan jy vasstel wat jehovah sal behaag ?
+"
+"die bybel sê vir ons dat “ vroue hulle met goed versorgde kleredrag moet versier , met beskeidenheid en gesonde verstand , nie met haarvlegtery en goud of pêrels of baie duur klere nie , maar soos dit vroue betaam wat bely dat hulle god vereer , naamlik deur goeie werke ” .
+"
+"hierdie raad is natuurlik op al jehovah se knegte , mans sowel as vroue , van toepassing .
+"
+"as ons beskeie is , dink ons aan die uitwerking wat ons kleredrag op ander kan hê .
+"
+"en omdat ons lief is vir ons broers , wil ons hulle nie ontstel of aanstoot gee nie .
+"
+"as ons in ag neem wat die bybel sê , kan dit ons help om jehovah se denke te leer ken en kan ons besluite neem wat hom sal behaag .
+"
+"15 , 16 . ( a ) hoe voel jehovah daaroor as ons aan seksueel onsedelike dinge bly dink ?
+"
+"( b ) hoe kan ons vasstel wat jehovah behaag wanneer ons vermaak kies ?
+"
+"( c ) wat moet ons doen wanneer ons belangrike besluite moet neem ?
+"
+"die bybel sê vir ons dat dit jehovah diep seermaak wanneer mense goddeloos optree en aan slegte dinge dink .
+"
+"( lees genesis 6 : 5 , 6 . )
+"
+"dit is duidelik dat jehovah nie wil hê dat ons oor seksuele onsedelikheid moet fantaseer nie .
+"
+"trouens , as ons aan sulke dinge bly dink , sal ons dit dalk uiteindelik doen .
+"
+"jehovah wil hê dat ons eerder aan rein en goeie dinge moet dink .
+"
+"die dissipel jakobus het geskryf : “ die wysheid van bo is allereers kuis , dan vredeliewend , redelik , bereid om te gehoorsaam , vol barmhartigheid en goeie vrugte , maak nie partydige onderskeid nie , is nie huigelagtig nie ” .
+"
+"die bybel leer ons dus dat ons enige vermaak moet vermy wat onrein gedagtes of begeertes by ons kan wek .
+"
+"en as ons ’ n duidelike begrip het van wat jehovah liefhet en wat hy haat , sal dit vir ons maklik wees om te weet watter boeke , rolprente of speletjies ons kan kies .
+"
+"dit sal nie vir ons nodig wees om ander te vra wat ons moet doen nie .
+"
+"wanneer ons ’ n besluit moet neem , is daar dikwels verskeie opsies wat jehovah sal behaag .
+"
+"maar wanneer ons ’ n baie belangrike besluit moet neem , sal dit dalk goed wees om ’ n ouer man of ’ n ander ervare broer of suster vir raad te vra .
+"
+"ons moet hierdie persoon natuurlik nie vra om die besluit vir ons te neem nie .
+"
+"ons moet eerder goed nadink oor wat die bybel sê en dan ons eie besluit neem .
+"
+"die apostel paulus het gesê : “ elkeen sal sy eie vrag van verantwoordelikheid dra . ” — galasiërs 6 : 5 , voetnoot in nw .
+"
+"watter voordele geniet ons as ons besluite neem wat jehovah behaag ?
+"
+"wanneer ons besluite neem wat jehovah behaag , kom ons nader aan hom en geniet ons sy goedkeuring en seën .
+"
+"dit versterk ons geloof in jehovah .
+"
+"ons moet dus peins oor wat ons in die bybel lees sodat ons jehovah se denke kan leer ken .
+"
+"ons sal natuurlik altyd nuwe dinge oor jehovah leer .
+"
+"maar as ons hard werk om hom nou beter te leer ken , sal ons wys word en goeie besluite kan neem .
+"
+"mense se idees en planne verander , maar jehovah verander nooit nie .
+"
+"die psalmis het gesê : “ die raad [ of “ besluite ” ] van jehovah sal tot onbepaalde tyd standhou ; die gedagtes van sy hart is van geslag tot geslag ” .
+"
+"dit is duidelik dat ons die beste besluite sal neem as ons ons denke in ooreenstemming bring met jehovah se denke en dan doen wat hom behaag .
+"
+"wat leer dit my omtrent jehovah ? .
+"
+"hoe kan ek hierdie inligting gebruik . . .
+"
+"by die huis ?
+"
+"by die werk ?
+"
+"by die skool ?
+"
+"om te begryp wat die wil van jehovah is : om uit te vind , of te verstaan , wat jehovah se denke oor ’ n saak is en wat hom behaag .
+"
+"dit is veral belangrik as daar nie ’ n spesifieke wet in die bybel is nie .
+"
+"ons moet bid en peins oor wat ons omtrent jehovah geleer het , oor wat hy liefhet en haat en oor wat hy in die verlede gedoen het
+"
+"“ word verander deur julle verstand te hervorm . ” — romeine 12 : 2 .
+"
+"liedere : 61 , 52
+"
+"waarom moet ons ná ons doop aanhou om veranderinge in ons lewe aan te bring ?
+"
+"waarom verwag god dat ons ons moet inspan om ons swakhede te oorkom ?
+"
+"wat kan ons doen sodat god se woord ons lewe voortdurend kan verander ?
+"
+"1 - 3 . ( a ) watter veranderinge is dalk ná ons doop moeilik om aan te bring ?
+"
+"( b ) watter vrae kom dalk by ons op wanneer dit moeiliker is om vordering te maak as wat ons verwag het ?
+"
+"kevin het jare lank gedobbel , gerook , te veel gedrink en dwelms gebruik .
+"
+"toe het hy van jehovah geleer en wou hy sy vriend word .
+"
+"maar om dit te doen , moes hy groot veranderinge in sy lewe aanbring .
+"
+"met jehovah se hulp en die krag van sy woord , die bybel , was kevin in staat om te verander . — hebreërs 4 : 12 .
+"
+"nadat kevin gedoop is , moes hy nog steeds veranderinge in sy persoonlikheid aanbring sodat hy ’ n beter christen kon word .
+"
+"hy het byvoorbeeld sy humeur baie gou verloor .
+"
+"kevin het gesê : “ dit was baie moeiliker om te leer om my humeur in toom te hou as wat dit was om die slegte gewoontes te oorkom wat ek voor my doop gehad het ! ”
+"
+"maar intense gebede en deeglike bybelstudie het hom gehelp om veranderinge aan te bring .
+"
+"voor ons doop moes baie van ons groot veranderinge in ons lewe aanbring sodat ons in ooreenstemming met bybelstandaarde kon lewe .
+"
+"maar ons besef dat daar nog steeds kleiner veranderinge is wat ons moet aanbring om meer soos god en christus te wees .
+"
+"byvoorbeeld , ons besef miskien dat ons baie kla of dikwels skinder en gemene dinge oor ander sê .
+"
+"of dalk swig ons soms voor mensevrees .
+"
+"ons probeer miskien al jare lank om te verander , maar ons hou aan om dieselfde foute te maak .
+"
+"ons wonder dalk : ‘ waarom is dit so moeilik vir my om hierdie kleiner veranderinge aan te bring ?
+"
+"wat moet ek doen om toe te pas wat die bybel sê sodat ek my persoonlikheid voortdurend kan verbeter ? ’
+"
+"waarom kan ons jehovah nie ten volle behaag nie ?
+"
+"ons is lief vir jehovah , en dit is ons hartsbegeerte om hom te behaag .
+"
+"maar weens ons onvolmaaktheid kan ons hom ongelukkig nie ten volle behaag nie .
+"
+"ons voel dikwels soos die apostel paulus , wat gesê het dat hy die begeerte het om te doen wat goed is , maar nie die vermoë het om hierdie begeerte uit te voer nie . — romeine 7 : 18 ; jakobus 3 : 2 .
+"
+"watter veranderinge het ons aangebring voordat ons gedoop is , maar teen watter swakhede stry ons miskien nog steeds ?
+"
+"voordat ons deel van die gemeente kon wees , moes ons ophou om dinge te beoefen wat jehovah haat .
+"
+"maar ons is nog steeds onvolmaak .
+"
+"daarom hou ons aan om foute te maak , al is ons reeds jare lank gedoop .
+"
+"van tyd tot tyd kom verkeerde begeertes en gevoelens dalk by ons op , of ons vind dit miskien moeilik om ’ n sekere swakheid te oorkom .
+"
+"trouens , ons moet dalk jare lank teen dieselfde swakheid stry .
+"
+"6 , 7 . ( a ) waarom kan ons jehovah se vriende wees , al is ons onvolmaak ?
+"
+"( b ) waarom moet ons nie huiwer om jehovah om vergifnis te vra nie ?
+"
+"al is ons onvolmaak , kan ons nog steeds jehovah se vriend wees en hom dien .
+"
+"moenie vergeet hoe jou vriendskap met jehovah begin het nie .
+"
+"hy was die een wat die goeie in jou gesien het en wat wou hê dat jy hom moet leer ken .
+"
+"hy het ook geweet dat jy swakhede het en dat jy foute sal maak .
+"
+"maar jehovah wou nog steeds hê dat jy sy vriend moet wees .
+"
+"jehovah se liefde vir ons is so groot dat hy ons ’ n kosbare gawe gegee het .
+"
+"hy het sy seun , jesus , aarde toe gestuur sodat hy sy lewe as ’ n losprys vir ons sondes kon gee .
+"
+"wanneer ons ’ n fout begaan , kan ons jehovah om vergifnis vra .
+"
+"en weens die losprys kan ons seker wees dat hy ons sal vergewe en dat ons nog steeds sy vriende sal kan wees .
+"
+"hou in gedagte dat jesus vir berouvolle sondaars gesterf het .
+"
+"daarom moet ons nooit ophou om jehovah te vra om ons te vergewe nie , al voel ons miskien dat ons onrein of sondig is .
+"
+"as ons hom nie vra om ons te vergewe nie , sal dit wees soos om te weier om ons hande te was wanneer dit vuil is .
+"
+"hoe dankbaar is ons tog dat jehovah dit vir ons moontlik gemaak het om sy vriende te wees , al is ons onvolmaak ! — lees 1 timoteus 1 : 15 .
+"
+"as ons nader aan jehovah wil kom , moet ons hom en sy seun voortdurend probeer navolg
+"
+"waarom moet ons nie ons swakhede ignoreer nie ?
+"
+"ons kan natuurlik nie ons swakhede ignoreer of verskonings daarvoor bly maak nie .
+"
+"jehovah sê vir ons watter soort mense hy as sy vriende wil hê .
+"
+"as ons dus nader aan hom wil kom , moet ons hom en sy seun voortdurend probeer navolg .
+"
+"ons moet ook teen ons verkeerde begeertes stry , en dalk sal ons party van hierdie begeertes selfs kan oorkom .
+"
+"ongeag hoe lank ons al gedoop is , ons moet ons persoonlikheid voortdurend verbeter . — 2 korintiërs 13 : 11 .
+"
+"hoe weet ons dat dit ’ n voortdurende proses is om ons met die nuwe persoonlikheid te beklee ?
+"
+"die apostel paulus het vir christene gesê : “ julle [ moet ] die ou persoonlikheid . . . aflê , wat met julle vroeëre lewenswandel ooreenkom en wat volgens sy bedrieglike begeertes verderf word ; maar [ julle moet vernuwe ] word in die krag wat julle verstand aandryf en julle met die nuwe persoonlikheid . . . beklee , wat na god se wil in ware regverdigheid en lojaliteit geskep is ” .
+"
+"die woorde ‘ julle moet vernuwe word ’ dui daarop dat dit ’ n voortdurende proses is om te verander en om ons “ met die nuwe persoonlikheid [ te ] beklee ” .
+"
+"ons kan dus altyd meer omtrent jehovah se eienskappe leer , ongeag hoe lank ons hom al dien .
+"
+"en die bybel kan ons help om voortdurend veranderinge in ons persoonlikheid aan te bring sodat ons meer soos god kan word .
+"
+"wat moet ons doen as ons voortdurend veranderinge wil aanbring , en watter vrae ontstaan ?
+"
+"ons almal wil die bybel se raad volg .
+"
+"maar ons moet ons inspan as ons voortdurend veranderinge wil aanbring .
+"
+"waarom verg dit soveel inspanning ?
+"
+"kan jehovah dit nie vir ons makliker maak om te doen wat reg is nie ?
+"
+"waarom verwag jehovah dat ons ons moet inspan om ons swakhede te oorkom ?
+"
+"wanneer ons dink aan die heelal en alles daarin , besef ons dat jehovah die krag het om enigiets te doen .
+"
+"hy het byvoorbeeld die son gemaak , en dink net watter krag die son het .
+"
+"elke sekonde straal die son ’ n ontsaglike hoeveelheid lig en hitte uit , maar slegs ’ n klein hoeveelheid van hierdie energie is nodig om lewe op die aarde te onderhou .
+"
+"jehovah gee ook krag aan sy knegte hier op die aarde wanneer hulle dit nodig het .
+"
+"as jehovah wou , kon hy dit dus vir ons baie maklik gemaak het om teen ons swakhede te stry en om verkeerde begeertes te oorkom .
+"
+"waarom doen hy dit dan nie ?
+"
+"jehovah het ons wilsvryheid gegee .
+"
+"hy laat ons toe om self te besluit of ons hom wil gehoorsaam of nie .
+"
+"wanneer ons kies om hom te gehoorsaam en ons inspan om sy wil te doen , toon ons dat ons lief is vir hom en hom wil behaag .
+"
+"satan beweer dat jehovah nie die reg het om te heers nie .
+"
+"maar as ons jehovah gehoorsaam , toon ons dat ons hom as ons heerser wil hê .
+"
+"en ons kan seker wees dat ons liefdevolle vader dit waardeer wanneer ons ons inspan om hom te gehoorsaam .
+"
+"dit is nie maklik om ons swakhede te oorkom nie , maar as ons hard stry om dit te oorkom , toon ons dat ons lojaal is aan jehovah en hom as ons heerser wil hê .
+"
+"jehovah sê dus vir ons dat “ ywerige inspanning ” nodig is om sy eienskappe na te volg .
+"
+"wat moet ons doen om die eienskappe aan te kweek waarvoor jehovah lief is ?
+"
+"( sien die venster “ die bybel en gebed het hulle lewe verander ” . )
+"
+"pleks van self te besluit watter veranderinge ons moet aanbring , moet ons toelaat dat god ons hierin lei .
+"
+"romeine 12 : 2 sê : “ moenie langer na hierdie stelsel van dinge gevorm word nie , maar word verander deur julle verstand te hervorm , dat julle kan seker maak wat die goeie en aanneemlike en volmaakte wil van god is . ”
+"
+"om uit te vind wat jehovah van ons verwag , moet ons dus gebruik maak van die hulp wat hy voorsien .
+"
+"ons moet die bybel elke dag lees , peins oor wat ons lees en jehovah in gebed vir sy heilige gees vra .
+"
+"dit kan ons help om te verstaan wat jehovah behaag en kan ons leer om soos jehovah te dink .
+"
+"dan sal ons denke , woorde en dade hom nog meer behaag .
+"
+"maar ons sal nog steeds teen ons swakhede moet stry . — spreuke 4 : 23 .
+"
+"versamel artikels wat in ons publikasies verskyn of bybeltekste wat jou help om teen jou swakhede te stry en lees dit weer van tyd tot tyd ( sien paragraaf 15 )
+"
+"ons moet die bybel nie net elke dag lees nie ; ons moet dit ook studeer met behulp van ons publikasies , soos die wagtoring en ontwaak !
+"
+"baie artikels in hierdie tydskrifte leer ons hoe ons jehovah se eienskappe kan navolg en hoe ons teen ons swakhede kan stry .
+"
+"ons vind miskien sekere artikels of tekste wat ons baie help .
+"
+"ons kan dit versamel sodat ons dit van tyd tot tyd weer kan lees .
+"
+"waarom moet ons nie mismoedig voel as dit lank neem om veranderinge in ons lewe aan te bring nie ?
+"
+"dit neem tyd om te leer hoe om jehovah se eienskappe na te volg .
+"
+"as jy voel dat jy nog nie al die veranderinge aangebring het wat jy wil nie , moet jy geduldig wees .
+"
+"aanvanklik sal jy jou dalk moet dwing om te doen wat die bybel sê .
+"
+"maar hoe meer jy jou denke en gedrag verander om jehovah te behaag , hoe makliker sal dit vir jou word om soos hy te dink en om te doen wat reg is . — psalm 37 : 31 ; spreuke 23 : 12 ; galasiërs 5 : 16 , 17 .
+"
+"na watter wonderlike toekoms kan ons uitsien as ons lojaal aan jehovah is ?
+"
+"ons sien uit na die tyd wanneer ons volmaak sal wees en jehovah vir ewig sal dien .
+"
+"dan sal ons nie meer teen enige swakhede hoef te stry nie , en dit sal baie makliker vir ons wees om jehovah na te volg .
+"
+"maar ons kan jehovah nou al dien omdat hy ons die gawe van die losprys gegee het .
+"
+"hoewel ons onvolmaak is , kan ons hom behaag as ons voortdurend hard werk om veranderinge aan te bring en as ons toepas wat hy ons in die bybel leer .
+"
+"hoe weet ons dat die bybel ons kan help om ons lewe voortdurend te verander ?
+"
+"kevin het alles in sy vermoë gedoen om te leer om sy humeur in toom te hou .
+"
+"hy het nagedink oor wat hy in die bybel gelees het en hard probeer om veranderinge in sy lewe aan te bring .
+"
+"hy het ook die raad van mede - christene gevolg .
+"
+"hoewel dit kevin ’ n paar jaar geneem het om te verbeter , het hy later as ’ n bedieningskneg gedien .
+"
+"en hy dien al die afgelope 20 jaar as ’ n ouer man .
+"
+"maar hy weet dat hy nog steeds teen sy swakhede moet stry .
+"
+"net soos kevin kan ons aanhou om ons persoonlikheid te verbeter .
+"
+"as ons dit doen , sal ons al hoe nader aan jehovah kom .
+"
+"en as ons alles in ons vermoë doen om hom te behaag , sal hy ons help om suksesvol te wees .
+"
+"ons kan seker wees dat ons met behulp van die bybel voortdurend veranderinge in ons lewe sal kan aanbring . — psalm 34 : 8 .
+"
+"[ 1 ] ( paragraaf 1 ) die naam is verander .
+"
+"russell het dikwels oor ander broers en susters gekla en gemeen dat hulle byna nooit iets reg kan doen nie .
+"
+"maria victoria het daarvan gehou om te skinder .
+"
+"linda het mensevrees gehad wanneer sy in die bediening uitgegaan het .
+"
+"hierdie drie gedoopte christene het gedink dat hulle nooit sal kan verander nie .
+"
+"russell : “ intense gebede tot jehovah en daaglikse bybellees het my gehelp .
+"
+"ek het gepeins oor 2 petrus 2 : 11 en oor die raad wat die ouer manne my gegee het , en dit het ’ n groot verskil gemaak . ”
+"
+"maria victoria : “ ek het vurig tot jehovah gebid om my te help om my tong in toom te hou .
+"
+"en ek het besef dat ek noue omgang met mense wat daarvan hou om te skinder , moet vermy .
+"
+"psalm 64 : 1 - 4 het my laat besef dat ek my nie langer aan skinderpraatjies skuldig moet maak nie , want mense vra god in gebed vir beskerming teen persone wat hulle tong so gebruik !
+"
+"ek het ook besef dat ek ’ n slegte voorbeeld vir ander sal wees en jehovah se naam oneer sal aandoen as ek aanhou skinder . ”
+"
+"linda : “ ek het goed vertroud geraak met ons traktate sodat dit vir my maklik sou wees om dit aan te bied .
+"
+"assosiasie met broers en susters wat aan verskeie aspekte van die bediening deelneem , het my baie gehelp .
+"
+"en ek hou aan om deur gebed op jehovah te vertrou . ”
+"
+"ons stry teen ons swakhede : ons het dalk swakhede wat nie maklik is om te oorkom nie of ons begaan dieselfde foute oor en oor .
+"
+"byvoorbeeld , ons is dalk ongeduldig , verloor maklik ons humeur of kla baie oor ander .
+"
+"ons moet ons voortdurend inspan om ons swakhede te oorkom , want ons weet dat dit jehovah sal behaag
+"
+"3 erken en waardeer jehovah as ons pottebakker
+"
+"9 laat jy die groot pottebakker toe om jou te vorm ?
+"
+"’ n pottebakker is ’ n ambagsman wat klei met die hand in pragtige voorwerpe vorm .
+"
+"in hierdie twee artikels sal ons sien waarom ons kan sê dat jehovah “ ons pottebakker ” is en wat ons moet doen om soos sagte klei in sy hande te wees .
+"
+"15 “ jehovah ons god is een jehovah ”
+"
+"in watter sin is jehovah ons god “ een jehovah ” ?
+"
+"hoe raak dit ons verhouding met hom en met ons broers en susters ?
+"
+"aangesien ons uit verskillende agtergronde kom , moet ons verstaan wat jehovah van ons vereis sodat hy “ ons god ” kan wees .
+"
+"21 moenie toelaat dat ander se foute jou laat struikel nie
+"
+"alle mense het foute en kan ander se gevoelens seermaak .
+"
+"hoe moet ons dus reageer wanneer iemand iets sê of doen wat ons gevoelens seermaak ?
+"
+"in hierdie artikel sal ons bybelvoorbeelde bespreek wat ons kan help .
+"
+"27 ’ n goddelike eienskap wat kosbaarder is as diamante
+"
+"“ o jehovah , . . . u is ons pottebakker ; en ons is almal die werk van u hand . ” — jesaja 64 : 8 .
+"
+"liedere : 89 , 26
+"
+"hoe jehovah besluit wie hy wil vorm ?
+"
+"waarom jehovah sy volk vorm ?
+"
+"hoe god diegene vorm wat hulle aan hom onderwerp ?
+"
+"waarom is jehovah ver verhewe bo enige menslike pottebakker ?
+"
+"in november 2010 is daar in engeland ’ n bod van byna 70 miljoen dollar op ’ n chinese vaas gemaak .
+"
+"dit is verbasend dat ’ n pottebakker iets so algemeen en goedkoop soos klei kon gebruik om so ’ n pragtige en duur vaas te vorm .
+"
+"jehovah , ons pottebakker , is ver verhewe bo enige menslike pottebakker .
+"
+"die bybel sê dat jehovah ’ n volmaakte mens “ uit stof van die aarde ” , dit wil sê uit klei , gevorm het .
+"
+"daardie mens , adam , was ’ n “ seun van god ” en is geskep met die vermoë om god se eienskappe na te volg . — lukas 3 : 38 .
+"
+"hoe kan ons die gesindheid van die berouvolle israeliete navolg ?
+"
+"toe adam teen sy skepper in opstand gekom het , het hy die voorreg verloor om ’ n seun van god te wees .
+"
+"maar baie van adam se nakomelinge het jehovah as hulle heerser gekies .
+"
+"deur hulle nederig aan hulle skepper te onderwerp , het hulle getoon dat hulle hom , en nie satan nie , as hulle vader en pottebakker verkies .
+"
+"hulle lojaliteit aan god herinner ons aan wat die berouvolle israeliete gesê het : “ o jehovah , u is ons vader .
+"
+"ons is die klei , en u is ons pottebakker ; en ons is almal die werk van u hand . ” — jesaja 64 : 8 .
+"
+"vandag doen jehovah se ware aanbidders hulle bes om ook so ’ n nederige gesindheid te hê en hulle aan hom te onderwerp .
+"
+"hulle beskou dit as ’ n eer om jehovah hulle vader te noem , en hulle wil hê dat hy hulle pottebakker moet wees .
+"
+"is ons gewillig om soos sagte klei te wees wat god in ’ n kosbare houer kan omskep ?
+"
+"beskou ons elkeen van ons broers en susters as iemand wat nog deur god gevorm word ?
+"
+"om ons te help om die regte gesindheid te hê , sal ons bespreek hoe jehovah besluit wie hy wil vorm , waarom hy hulle vorm en hoe hy dit doen .
+"
+"hoe besluit jehovah wie hy na hom toe trek ?
+"
+"jehovah sien mense nie soos ons hulle sien nie .
+"
+"hy ondersoek eerder die hart en sien watter soort mens ons werklik is .
+"
+"( lees 1 samuel 16 : 7b . )
+"
+"jehovah het dit getoon toe hy die christengemeente gevorm het .
+"
+"hy het baie persone wat vanuit ’ n menslike oogpunt onaanvaarbaar sou wees , na hom en sy seun getrek .
+"
+"een so ’ n persoon was die fariseër met die naam saulus , “ ’ n lasteraar en ’ n vervolger en ’ n vermetele man ” .
+"
+"maar jehovah het saulus se hart ondersoek en het nie gedink dat hy ’ n stuk nuttelose klei is nie .
+"
+"jehovah het eerder gesien dat saulus omskep kon word in “ ’ n uitverkore vat ” om die boodskap “ na die nasies sowel as na konings en die kinders van israel te dra ” .
+"
+"van die ander wat jehovah gekies het sodat hy hulle “ vir ’ n eervolle gebruik ” kon vorm , het voormalige dronkaards , onsedelike mense en diewe ingesluit .
+"
+"toe hulle kennis van die skrif ingeneem het , het dit hulle geloof in jehovah versterk en het hulle hom toegelaat om hulle te vorm .
+"
+"ons moenie mense in ons gebied of in ons gemeente oordeel nie
+"
+"hoe moet vertroue in jehovah as ons pottebakker ons gesindheid beïnvloed teenoor ( a ) die mense in ons gebied ?
+"
+"( b ) ons broers en susters ?
+"
+"ons het die vertroue dat jehovah die regte mense kan kies en na hom toe kan trek .
+"
+"daarom moet ons nie mense in ons gebied of in ons gemeente oordeel nie .
+"
+"kyk byvoorbeeld hoe ’ n man met die naam michael gereageer het toe jehovah se getuies hom besoek het .
+"
+"hy sê : “ ek het gewoonlik net omgedraai en hulle geïgnoreer asof hulle nie bestaan nie .
+"
+"ek was baie onbeskof !
+"
+"later het ek ’ n gesin ontmoet wat ek weens hulle goeie gedrag bewonder het .
+"
+"groot was my skok toe ek uitvind dat hulle jehovah se getuies is !
+"
+"hulle gedrag het my beweeg om te ondersoek waarom ek bevooroordeeld teenoor die getuies is .
+"
+"ek het gou agtergekom dat my gesindheid gegrond was op onkunde en hoorsê , nie op feite nie . ”
+"
+"michael wou meer leer en het ’ n bybelstudie aanvaar .
+"
+"hy is later gedoop en het toe ’ n voltydse dienaar geword .
+"
+"as ons erken dat jehovah ons pottebakker is , sal ons gesindheid teenoor ons broers en susters ook verander .
+"
+"ons sal elkeen van hulle beskou as iemand wat nog deur jehovah gevorm word .
+"
+"dit is hoe jehovah hulle sien .
+"
+"hy sien die ware innerlike persoon en weet dat hulle onvolmaaktheid net tydelik is .
+"
+"hy weet ook watter soort mens elkeen van hulle kan word .
+"
+"ons kan jehovah navolg as ons dieselfde positiewe gesindheid teenoor ons broers het .
+"
+"ons kan selfs met ons pottebakker saamwerk om ons broers en susters te help om vordering te maak .
+"
+"die ouer manne in die gemeente moet ’ n goeie voorbeeld hierin stel . — efesiërs 4 : 8 , 11 - 13 .
+"
+"waarom waardeer jy jehovah se dissipline ?
+"
+"sommige sê dalk : ‘ eers toe ek my eie kinders gehad het , het ek my ouers se dissipline ten volle waardeer . ’
+"
+"wanneer ons ouer word , besef ons gewoonlik dat dissipline ’ n bewys van liefde is .
+"
+"( lees hebreërs 12 : 5 , 6 , 11 . )
+"
+"ja , jehovah het ons as sy kinders lief , en daarom dissiplineer , of vorm , hy ons geduldig .
+"
+"hy wil hê dat ons wys en gelukkig moet wees en hom as ons vader moet liefhê .
+"
+"hy hou nie daarvan om ons te sien ly nie , en hy wil ook nie hê dat ons moet sterf as “ kinders van die gramskap ” , dit wil sê as onberouvolle sondaars nie . — efesiërs 2 : 2 , 3 .
+"
+"jehovah het ons as sy kinders lief , en daarom dissiplineer , of vorm , hy ons geduldig
+"
+"hoe onderrig jehovah ons vandag , en hoe sal hierdie onderrigting in die toekoms voortduur ?
+"
+"voor ons jehovah leer ken het , het ons dalk talle slegte eienskappe gehad .
+"
+"maar jehovah het ons gevorm en gehelp om te verander , en daarom het ons nou pragtige eienskappe .
+"
+"ons is in ’ n geestelike paradys .
+"
+"dit is die spesiale omgewing wat jehovah in ons dag skep wat help om ons te vorm .
+"
+"ons voel veilig en beskerm daarin , al is die wêreld om ons goddeloos .
+"
+"diegene wat dalk in ’ n liefdelose gesin grootgeword het , ondervind nou die opregte liefde van hulle broers en susters in die geestelike paradys .
+"
+"en ons het geleer om liefde aan ander te betoon .
+"
+"maar bowenal het ons jehovah leer ken en ervaar ons nou sy vaderlike liefde . — jakobus 4 : 8 .
+"
+"in die nuwe wêreld sal ons ten volle by die geestelike paradys baat vind .
+"
+"ons sal ook die lewe in ’ n letterlike paradys geniet wat deur god se koninkryk regeer word .
+"
+"daar sal jehovah aanhou om ons te vorm — hy sal ons onderrig op ’ n wyse wat ons ons nie nou kan voorstel nie .
+"
+"jehovah sal ons ook verstandelik en liggaamlik tot volmaaktheid laat groei .
+"
+"ons sal sy onderrigting dan beter kan verstaan en ten volle kan gehoorsaam .
+"
+"ons moet jehovah dus toelaat om ons voortdurend te vorm , en ons moet vir hom wys dat ons hierdie blyk van sy liefde waardeer . — spreuke 3 : 11 , 12 .
+"
+"hoe het jesus die groot pottebakker se geduld en vaardigheid weerspieël ?
+"
+"soos ’ n vaardige pottebakker wat sy klei goed ken , ken jehovah , ons pottebakker , ons baie goed .
+"
+"hy weet wat ons swakhede en ons beperkings is en watter vooruitgang ons al gemaak het , en hy hou dit in gedagte terwyl hy elkeen van ons vorm .
+"
+"( lees psalm 103 : 10 - 14 . )
+"
+"wanneer ons kyk na hoe jesus op die onvolmaakthede van sy apostels gereageer het , help dit ons om te besef hoe jehovah ons beskou .
+"
+"soms het die apostels gestry oor wie die grootste is .
+"
+"hoe sou jy oor die apostels se optrede gevoel het as jy daar was ?
+"
+"jy sou miskien gedink het dat hulle nie soos sagte klei is nie .
+"
+"maar jesus het geweet dat hulle gevorm kan word as hulle luister na die raad wat hy op ’ n liefdevolle en geduldige wyse gegee het en as hulle sy nederigheid navolg .
+"
+"ná jesus se opstanding het die apostels god se gees ontvang en was hulle nie meer bekommerd oor wie die grootste is nie .
+"
+"hulle het eerder gekonsentreer op die werk wat jesus hulle gegee het . — handelinge 5 : 42 .
+"
+"hoe was dawid soos sagte klei , en hoe kan ons hom navolg ?
+"
+"vandag gebruik jehovah die bybel , sy heilige gees en die gemeente om ons te vorm .
+"
+"hoe kan die bybel ons vorm ?
+"
+"ons moet dit lees , daaroor peins en jehovah vra om ons te help om toe te pas wat ons leer .
+"
+"koning dawid het geskryf : “ wanneer ek op my rusbed aan u gedink het , peins ek gedurende die nagwake oor u ” .
+"
+"hy het ook geskryf : “ ek sal jehovah loof , wat my raad gegee het .
+"
+"ja , dawid het gepeins oor jehovah se raad en toegelaat dat dit sy diepste gedagtes en gevoelens vorm , selfs wanneer die raad moeilik was om te aanvaar .
+"
+"dawid het ’ n pragtige voorbeeld van nederigheid en gehoorsaamheid vir ons gestel .
+"
+"vra jou dus af : ‘ wanneer ek die bybel lees , peins ek daaroor en laat ek toe dat god se raad my diepste gedagtes en gevoelens raak ?
+"
+"kan ek dit in selfs groter mate doen ? ’ — psalm 1 : 2 , 3 .
+"
+"hoe vorm jehovah ons deur middel van heilige gees en die christengemeente ?
+"
+"heilige gees kan ons op verskeie maniere vorm .
+"
+"dit kan ons byvoorbeeld help om jesus se persoonlikheid na te volg en om die verskillende aspekte van die vrug van die gees te openbaar .
+"
+"een aspek daarvan is liefde .
+"
+"ons het god lief en wil hom gehoorsaam en deur hom gevorm word , want ons weet dat sy gebooie ons tot voordeel strek .
+"
+"die heilige gees kan ons ook die krag gee om die invloed van hierdie goddelose wêreld te weerstaan .
+"
+"toe die apostel paulus jonk was , is hy deur die trotse joodse godsdiensleiers beïnvloed .
+"
+"maar heilige gees het hom gehelp om te verander .
+"
+"hy het later geskryf : “ vir alles is ek sterk genoeg deur hom wat my krag gee ” .
+"
+"ons moet ook vir heilige gees vra , in die wete dat jehovah ons opregte gebede sal verhoor . — psalm 10 : 17 .
+"
+"jehovah gebruik christen - ouer manne om ons te vorm , maar ons moet hulle raad toepas ( sien paragraaf 12 , 13 )
+"
+"jehovah gebruik ook die gemeente en die ouer manne om elkeen van ons te vorm .
+"
+"as die ouer manne byvoorbeeld oplet dat ons ’ n swakheid het , probeer hulle ons help .
+"
+"maar die raad wat hulle ons gee , is nie op hulle eie idees gebaseer nie .
+"
+"hulle vra jehovah eerder nederig vir begrip en wysheid .
+"
+"dan doen hulle navorsing met behulp van die bybel en ons christelike publikasies om inligting te vind wat ons sal help .
+"
+"as die ouer manne na jou toe kom en jou liefdevolle raad gee , dalk oor jou kleredrag , moet jy onthou dat dit ’ n bewys is van god se liefde vir jou .
+"
+"as jy die raad toepas , sal jy soos sagte klei wees wat deur jehovah gevorm kan word , en jy sal daarby baat vind .
+"
+"hoe respekteer jehovah ons wilsvryheid , al het hy die reg om ons te vorm ?
+"
+"as ons verstaan hoe jehovah ons vorm , kan dit ons help om ’ n goeie verhouding met ons broers en susters te hê .
+"
+"ons sal ook ’ n positiewe gesindheid teenoor mense in ons gebied hê , insluitende ons bybelstudente .
+"
+"in bybeltye moes ’ n pottebakker klippies en ander onsuiwerhede uit die klei verwyder voordat hy dit kon vorm .
+"
+"die groot pottebakker , jehovah , help mense wat gevorm wil word .
+"
+"hy dwing hulle nie om te verander nie , maar maak eerder sy rein standaarde aan hulle bekend .
+"
+"hulle moet dan besluit of hulle die nodige veranderinge gaan maak .
+"
+"hoe toon bybelstudente dat hulle deur jehovah gevorm wil word ?
+"
+"kyk wat gebeur het met tessie , ’ n suster in australië .
+"
+"dit was nie vir haar moeilik om bybelwaarhede te verstaan nie .
+"
+"maar sy het nie juis vordering gemaak nie , en sy het nie vergaderinge bygewoon nie .
+"
+"die suster wat met haar gestudeer het , het tot jehovah gebid en het besluit om die studie stop te sit .
+"
+"by hulle studie het tessie vir die suster vertel waarom sy nie vordering maak nie .
+"
+"sy het gesê dat sy skynheilig voel omdat sy baie daarvan hou om te dobbel .
+"
+"maar sy het besluit om op te hou dobbel .
+"
+"tessie het kort daarna die vergaderinge begin bywoon en christelike eienskappe in haar lewe begin openbaar , al het party van haar voormalige vriende haar gespot .
+"
+"tessie is later gedoop en het ’ n gewone pionier geword , al het sy jong kinders gehad .
+"
+"ja , wanneer bybelstudente veranderinge begin maak om god te behaag , sal hy nader aan hulle kom en hulle in kosbare voorwerpe omskep .
+"
+"( a ) waarom is jy bly dat jehovah jou pottebakker is ?
+"
+"( b ) wat omtrent die vormingsproses sal ons in die volgende artikel bespreek ?
+"
+"vandag maak party pottebakkers nog steeds pragtige kleivoorwerpe met die hand .
+"
+"hulle vorm die klei met groot sorg . net so vorm jehovah ons geduldig deur middel van sy raad , en hy let noukeurig op hoe ons reageer .
+"
+"kan jy sien dat jehovah in jou belangstel ?
+"
+"sien jy hoe jehovah jou met groot sorg vorm ?
+"
+"indien wel , watter eienskappe sal jou help om soos sagte klei te wees wat jehovah kan vorm ?
+"
+"watter eienskappe moet jy vermy sodat jy nie soos harde klei word wat nie gevorm kan word nie ?
+"
+"en hoe kan ouers met jehovah saamwerk om hulle kinders te vorm ?
+"
+"jehovah vorm ons deur middel van die bybel , sy heilige gees en die gemeente .
+"
+"hy help ons om te verander sodat ons beter mense kan word
+"
+"soos die klei in die hand van die pottebakker , so is julle in my hand . ” — jeremia 18 : 6 .
+"
+"liedere : 60 , 22
+"
+"watter eienskappe kan ons verhard sodat ons jehovah se raad nie aanvaar nie ?
+"
+"watter eienskappe kan ons help om vormbaar in god se hande te bly ?
+"
+"hoe kan christenouers toon dat jehovah hulle pottebakker is ?
+"
+"waarom het god daniël beskou as ’ n “ besonder geliefde man ” , en hoe kan ons soos daniël gehoorsaam wees ?
+"
+"toe die jode in ballingskap in babilon was , was hulle omring deur afgode en deur mense wat bose geeste aanbid het .
+"
+"tog het getroue jode , soos daniël en sy drie vriende , geweier om deur die mense van babilon gevorm te word .
+"
+"daniël en sy vriende het jehovah as hulle pottebakker aanvaar en aangehou om slegs hom te aanbid .
+"
+"alhoewel daniël die grootste gedeelte van sy lewe in ’ n slegte omgewing was , het god se engel gesê dat hy ’ n “ besonder geliefde man ” was . — daniël 10 : 11 , 19 .
+"
+"in bybeltye het ’ n pottebakker klei soms in ’ n persvorm gedruk om ’ n spesifieke vorm te kry .
+"
+"vandag weet ware aanbidders dat jehovah die heerser van die heelal is en dat hy die gesag het om die nasies te vorm .
+"
+"( lees jeremia 18 : 6 . )
+"
+"god het ook die gesag om elkeen van ons te vorm .
+"
+"maar jehovah dwing niemand om te verander nie .
+"
+"hy wil eerder hê dat ons hom toelaat om ons te vorm .
+"
+"in hierdie artikel sal ons leer hoe ons soos sagte klei in god se hande kan bly .
+"
+"ons sal die volgende drie vrae bespreek : ( 1 ) hoe kan ons eienskappe vermy wat kan veroorsaak dat ons god se raad verwerp en soos harde klei word ?
+"
+"( 2 ) hoe kan ons eienskappe aankweek wat ons kan help om gehoorsaam en soos sagte klei te bly ?
+"
+"( 3 ) hoe kan christenouers met god saamwerk wanneer hulle hulle kinders vorm ?
+"
+"watter eienskappe kan ons hart verhard ?
+"
+"“ bewaak jou hart meer as enigiets anders wat bewaar moet word , want daaruit is die oorspronge van die lewe ” , sê spreuke 4 : 23 .
+"
+"om te voorkom dat ons hart verhard , moet ons negatiewe eienskappe soos trots , die beoefening van sonde en ’ n gebrek aan geloof vermy .
+"
+"as ons nie versigtig is nie , kan hierdie eienskappe veroorsaak dat ons ongehoorsaam en opstandig word .
+"
+"dit het met koning ussia van juda gebeur .
+"
+"( lees 2 kronieke 26 : 3 - 5 , 16 - 21 . )
+"
+"aanvanklik was ussia gehoorsaam en het hy ’ n goeie verhouding met god gehad , en daarom het god hom voorspoedig gemaak .
+"
+"maar “ toe hy sterk geword het , het sy hart . . . hoogmoedig geword ” .
+"
+"hy het so trots geword dat hy reukwerk in die tempel probeer brand het , al was net die priesters veronderstel om dit te doen .
+"
+"toe die priesters vir hom sê dat hy dit nie mag doen nie , het ussia baie kwaad geword !
+"
+"jehovah het die trotse koning verneder , en hy was ’ n melaatse tot sy dood toe . — spreuke 16 : 18 .
+"
+"wat kan gebeur as ons nie waak teen trots nie ?
+"
+"as ons trots is , kan ons begin dink dat ons beter is as ander en die raad wat ons uit die bybel ontvang , begin verwerp .
+"
+"dit is wat met ’ n ouer man met die naam jim gebeur het .
+"
+"hy het nie met die ander ouer manne oor ’ n situasie in die gemeente saamgestem nie .
+"
+"jim sê : “ ek het vir die broers gesê dat hulle nie liefdevol is nie , en ek het die vergadering verlaat . ”
+"
+"omtrent ses maande later het hy na ’ n ander gemeente gegaan , maar hy is nie daar as ’ n ouer man aangestel nie .
+"
+"jim was baie teleurgesteld .
+"
+"hy was so oortuig dat hy reg is dat hy opgehou het om jehovah te dien en tien jaar lank onbedrywig was .
+"
+"hy sê : “ ek was trots en het jehovah begin blameer vir wat gebeur het .
+"
+"deur die jare heen het die broers my besoek en met my probeer redeneer , maar ek het hulle hulp geweier . ”
+"
+"jim sê : “ na my mening was die ander verkeerd , en ek kon net nie ophou om daaraan te dink nie . ”
+"
+"sy voorbeeld toon dat trots kan veroorsaak dat ons ons verkeerde gedrag verdedig .
+"
+"wanneer dit gebeur , is ons nie meer soos sagte klei nie .
+"
+"het ’ n broer of suster jou al ooit aanstoot gegee ?
+"
+"was jy al ooit ontevrede omdat jy ’ n voorreg verloor het ?
+"
+"het jy trots geword , of het jy besef dat vrede met jou broer en lojaliteit teenoor jehovah van die grootste belang is ? — lees psalm 119 : 165 ; kolossense 3 : 13 .
+"
+"wat kan gebeur as ons sonde beoefen ?
+"
+"wanneer iemand sonde beoefen of selfs in die geheim sondig , kan dit vir hom moeilik wees om goddelike raad te aanvaar .
+"
+"dit kan dan makliker word om te sondig .
+"
+"een broer het gesê dat sy verkeerde gedrag hom later nie meer gepla het nie . ’ n ander broer , wat ’ n ruk lank die gewoonte gehad het om na pornografie te kyk , het later gesê : “ ek het gevind dat ek ’ n kritiese gesindheid teenoor die ouer manne begin ontwikkel het . ”
+"
+"hierdie gewoonte het sy verhouding met jehovah geskaad .
+"
+"toe ander daarvan uitvind , het hy hulp van die ouer manne ontvang .
+"
+"ons almal is natuurlik onvolmaak .
+"
+"maar as ons krities word teenoor diegene wat ons raad gee of as ons verskonings maak wanneer ons iets verkeerds doen eerder as om god te vra om ons te vergewe en ons te help , kan ons hart begin verhard .
+"
+"die ongehoorsame israeliete het in die wildernis gesterf weens hulle harte wat verhard het en hulle gebrek aan geloof
+"
+"7 , 8 . ( a ) hoe toon die voorbeeld van die eertydse israeliete dat ’ n gebrek aan geloof ons hart kan verhard ?
+"
+"( b ) wat is die les vir ons ?
+"
+"toe jehovah die israeliete uit egipte bevry het , het hulle hom baie wonderwerke sien verrig .
+"
+"ten spyte hiervan het hulle harte verhard toe hulle naby die beloofde land was .
+"
+"hulle het nie geloof in god gehad nie .
+"
+"in plaas daarvan om op jehovah te vertrou , het hulle bang geword en teen moses gemurmureer .
+"
+"hulle wou selfs teruggaan na egipte waar hulle slawe was !
+"
+"jehovah was diep seergemaak en het gesê : “ hoe lank sal hierdie volk my met minagting bejeën ? ” .
+"
+"daardie israeliete het in die wildernis gesterf weens hulle harte wat verhard het en hulle gebrek aan geloof .
+"
+"vandag is ons baie naby aan die nuwe wêreld , en ons geloof word getoets .
+"
+"ons moet die gehalte van ons geloof ondersoek .
+"
+"hoe kan ons seker maak dat ons geloof sterk is ?
+"
+"ons kan jesus se woorde in matteus 6 : 33 ondersoek .
+"
+"vra jou af : ‘ toon my doelwitte en besluite dat ek jesus se woorde werklik glo ?
+"
+"sal ek van vergaderinge of velddiens wegbly om meer geld te maak ?
+"
+"wat sal ek doen as my werk meer van my tyd en energie begin vereis ?
+"
+"sal ek toelaat dat hierdie wêreld my vorm en my selfs verhoed om jehovah te dien ? ’
+"
+"waarom moet ons ‘ voortdurend toets ’ of ons in die geloof is , en hoe kan ons dit doen ?
+"
+"as ons nie toepas wat die bybel sê oor slegte assosiasie , uitsetting of ontspanning nie , kan ons hart begin verhard .
+"
+"wat moet jy doen as dit met jou begin gebeur ?
+"
+"dit is dringend dat jy jou geloof ondersoek !
+"
+"die bybel sê : “ toets voortdurend of julle in die geloof is , stel julleself voortdurend op die proef ” .
+"
+"wees eerlik met jouself en gebruik god se woord gereeld om jou denke reg te stel .
+"
+"wat kan ons help om soos sagte klei in jehovah se hande te wees ?
+"
+"om ons te help om soos sagte klei te bly , het god ons sy woord , die christengemeente en die bediening gegee .
+"
+"as ons daagliks die bybel lees en daaroor peins , sal dit ons help om soos sagte klei in jehovah se hande te wees sodat hy ons kan vorm .
+"
+"jehovah het die konings van israel beveel om ’ n afskrif van god se wet te maak en elke dag daarin te lees .
+"
+"die apostels het geweet dat hulle die skrif moes lees en daaroor moes peins as hulle suksesvol in hulle bediening wou wees .
+"
+"hulle het gedeeltes uit die hebreeuse geskrifte honderde kere in hulle geskrifte aangehaal , en wanneer hulle vir mense gepreek het , het hulle hulle aangespoor om ook die skrif te gebruik .
+"
+"ons besef ook dat dit belangrik is om god se woord elke dag te lees en daaroor te peins .
+"
+"dit help ons om nederig te bly , wat dit vir jehovah moontlik maak om ons te vorm .
+"
+"maak gebruik van god se voorsienings om soos sagte klei te bly ( sien paragraaf 10 - 13 )
+"
+"hoe kan jehovah die christengemeente gebruik om elkeen van ons te vorm ?
+"
+"jehovah weet wat elkeen van ons nodig het , en hy gebruik die christengemeente om ons te vorm .
+"
+"jim , wat vroeër genoem is , het sy gesindheid begin verander toe ’ n ouer man belangstelling in hom getoon het .
+"
+"jim sê : “ hy het my nooit die skuld gegee vir my situasie of my gekritiseer nie .
+"
+"hy het eerder positief gebly en gesê dat hy my graag wil help . ”
+"
+"ná omtrent drie maande het die ouer man jim na ’ n vergadering genooi .
+"
+"jim sê dat die gemeente hom hartlik terugverwelkom het en dat hulle liefde hom gehelp het om sy denke te verander .
+"
+"hy het tot die besef gekom dat sy gevoelens nie die hoofsaak is nie .
+"
+"die ouer manne in die gemeente en jim se vrou het hom aangemoedig , en hy het geleidelik weer sy verhouding met jehovah versterk .
+"
+"jim het ook baat gevind by artikels soos “ jehovah dra nie die skuld nie ” en “ dien jehovah lojaal ” , in die wagtoring van 15 november 1992 .
+"
+"later het jim weer as ’ n ouer man gedien .
+"
+"sedertdien het hy ander broers gehelp om soortgelyke probleme op te los en hulle geloof te versterk .
+"
+"hy sê hy het gedink dat hy ’ n hegte verhouding met jehovah gehad het , maar eintlik het hy nie !
+"
+"hy is spyt dat hy weens trots eerder op ander se foute gekonsentreer het as op die belangriker dinge . — 1 korintiërs 10 : 12 .
+"
+"wanneer ons christus navolg , voel mense aangetrokke tot ons boodskap en kan dit hulle gesindheid teenoor ons verander
+"
+"watter eienskappe kan ons in die veldbediening aanleer , en met watter voordele ?
+"
+"die veldbediening kan ons ook vorm en ons help om beter mense te word .
+"
+"wanneer ons die goeie nuus verkondig , moet ons eienskappe soos nederigheid en die verskillende aspekte van die vrug van god se gees openbaar .
+"
+"dink aan die goeie eienskappe wat jy al in die veldbediening aangeleer het .
+"
+"wanneer ons christus navolg , voel mense aangetrokke tot ons boodskap en kan dit hulle gesindheid teenoor ons verander .
+"
+"byvoorbeeld , toe twee getuies in australië in die huis - tot - huis - bediening met ’ n vrou probeer praat het , het sy baie kwaad geword en was sy onbeskof teenoor hulle .
+"
+"maar die getuies het respekvol teenoor haar gebly .
+"
+"later was die vrou spyt oor haar optrede , en sy het ’ n brief aan die takkantoor geskryf .
+"
+"sy het om verskoning gevra vir haar gedrag .
+"
+"sy het gesê : “ ek was dwaas om twee mense wat god se woord verkondig , op so ’ n manier weg te wys . ”
+"
+"hierdie ondervinding toon hoe belangrik dit is om sagmoedig te wees in die predikingswerk .
+"
+"ja , ons bediening help ander , maar dit help ons ook om ons persoonlikheid te verbeter .
+"
+"wat moet ouers doen om hulle kinders op ’ n suksesvolle wyse te vorm ?
+"
+"die meeste jong kinders is nederig en gretig om te leer .
+"
+"dit sal dus verstandig wees van ouers om hulle kinders van kleins af die waarheid te leer en hulle te help om dit lief te kry .
+"
+"om suksesvol te wees , moet ouers self vir die waarheid lief wees en toepas wat die bybel sê .
+"
+"as ouers dít doen , sal dit makliker vir hulle kinders wees om die waarheid lief te kry .
+"
+"en kinders sal verstaan dat die dissipline van hulle ouers bewys dat hulle ouers en jehovah hulle liefhet .
+"
+"hoe moet ouers toon dat hulle op god vertrou as hulle kind uitgesit word ?
+"
+"al maak ouers hulle kinders in die waarheid groot , verlaat party kinders jehovah of word hulle uitgesit .
+"
+"wanneer dit gebeur , bring dit groot hartseer vir die familie mee . ’ n suster in suid - afrika het gesê : “ toe my broer uitgesit is , was dit asof hy gesterf het .
+"
+"dit was hartverskeurend ! ”
+"
+"maar wat het sy en haar ouers gedoen ?
+"
+"hulle het die riglyne in die bybel gevolg .
+"
+"( lees 1 korintiërs 5 : 11 , 13 . )
+"
+"die ouers het besef dat dit tot almal se voordeel sal wees as hulle god se raad gehoorsaam .
+"
+"hulle het geweet dat uitsetting liefdevolle dissipline van jehovah is .
+"
+"daarom het hulle slegs met hulle seun in aanraking gekom wanneer baie belangrike familiesake hanteer moes word .
+"
+"hoe het die seun gevoel ?
+"
+"later het hy gesê : “ ek het geweet dat my familie my nie haat nie , maar dat hulle jehovah en sy organisasie gehoorsaam . ”
+"
+"hy het ook gesê : “ wanneer jy gedwing word om jehovah te smeek om jou te help en te vergewe , besef jy hoe nodig jy hom het . ”
+"
+"stel jou die familie se vreugde voor toe hierdie jong man na jehovah teruggekeer het !
+"
+"ja , ons sal gelukkig en suksesvol wees as ons god altyd gehoorsaam . — spreuke 3 : 5 , 6 ; 28 : 26 .
+"
+"wanneer ons nederig is en jehovah altyd gehoorsaam , sal ons baie geliefd by hom wees
+"
+"waarom moet ons jehovah altyd gehoorsaam , en hoe sal ons daarby baat vind ?
+"
+"die profeet jesaja het voorspel dat die jode in babilon berou sou toon en sou sê : “ o jehovah , u is ons vader .
+"
+"ons is die klei , en u is ons pottebakker ; en ons is almal die werk van u hand . ”
+"
+"hulle sou jehovah ook smeek : “ moenie vir ewig aan ons oortreding dink nie .
+"
+"kyk tog asseblief : ons is almal u volk ” .
+"
+"wanneer ons nederig is en jehovah altyd gehoorsaam , word ons baie geliefd by hom , soos daniël .
+"
+"jehovah sal ons bly vorm deur middel van sy woord , gees en organisasie sodat ons eendag volmaakte “ kinders van god ” sal word . — romeine 8 : 21 .
+"
+"ons hart kan verhard as negatiewe eienskappe , soos trots , veroorsaak dat ons die raad en riglyne van jehovah en sy organisasie verwerp
+"
+"die man met ’ n sekretaris se inkhoring stel jesus christus voor .
+"
+"hy merk diegene wat behoue sal bly
+"
+"hulle beeld die hemelse magte af wat betrokke was by die vernietiging van jerusalem en wat ook betrokke sal wees by die vernietiging van satan se goddelose wêreld by armageddon .
+"
+"dit is ’ n aanpassing in ons begrip .
+"
+"voor 607 vhj het jehovah vir esegiël ’ n visioen gegee om te toon wat in jerusalem sou gebeur voordat dit vernietig sou word .
+"
+"in die visioen het esegiël die goddelose dinge gesien wat daar plaasgevind het .
+"
+"toe het hy ses manne gesien wat elkeen ’ n “ wapen om mee te verbrysel in sy hand ” gehad het .
+"
+"daar was ook ’ n man saam met hulle wat “ in linne geklee was ” en wat “ ’ n sekretaris se inkhoring ” gehad het .
+"
+"hierdie man is beveel om deur die stad te trek en “ ’ n merk [ te ] maak op die voorkoppe van die mense wat sug en steun oor al die verfoeilike dinge wat daarin gedoen word ” .
+"
+"toe is die ses manne met die wapens beveel om almal in die stad dood te maak wat nie die merk het nie .
+"
+"wat kan ons uit hierdie visioen leer , en wie is die man met ’ n sekretaris se inkhoring ?
+"
+"esegiël het hierdie visioen in 612 vhj gesien .
+"
+"dit is ’ n profesie wat vyf jaar later sy eerste vervulling ondergaan het toe jehovah die babiloniese leër toegelaat het om jerusalem te vernietig .
+"
+"jehovah het die babiloniërs dus gebruik om sy ongehoorsame volk te straf .
+"
+"maar wat van die regverdige jode wat nie saamgestem het met al die slegte dinge wat in die stad beoefen is nie ?
+"
+"jehovah het seker gemaak dat hulle gered word .
+"
+"in die visioen het esegiël mense nie letterlik gemerk of deelgeneem aan die vernietiging van die stad nie .
+"
+"dit was eerder die engele wat die vernietiging van jerusalem gerig het .
+"
+"hierdie profesie gee ons dus ’ n kykie in wat in die hemel gebeur .
+"
+"jehovah het vir sy engele die opdrag gegee om toe te sien dat die goddeloses vernietig word en om seker te maak dat die regverdiges behoue bly .
+"
+"hierdie profesie sal ook in die toekoms vervul word .
+"
+"ons het in die verlede gesê dat die man met ’ n sekretaris se inkhoring die gesalfdes voorstel wat nog op die aarde lewe .
+"
+"ons het ook gesê dat mense die merk vir oorlewing kry as hulle gunstig reageer op die goeie nuus wat ons verkondig .
+"
+"maar dit het onlangs duidelik geword dat ons ons verduideliking van hierdie profesie moet aanpas .
+"
+"volgens matteus 25 : 31 - 33 is dit jesus wat mense oordeel .
+"
+"hy sal dit in die toekoms gedurende die groot verdrukking doen .
+"
+"dan sal diegene wat as skape geoordeel word , behoue bly , en diegene wat as bokke geoordeel word , vernietig word .
+"
+"wat leer ons dus uit esegiël se visioen ?
+"
+"hier is vyf lesse :
+"
+"voordat jerusalem vernietig is , het esegiël , sowel as jeremia en jesaja , die volk gewaarsku oor wat met die stad sou gebeur .
+"
+"hulle het as wagte opgetree .
+"
+"vandag gebruik jehovah ’ n klein groepie gesalfdes om sy volk te onderrig en ander te waarsku voordat die groot verdrukking uitbreek .
+"
+"trouens , god se hele volk , dit wil sê christus se huisknegte , neem deel aan hierdie waarskuwingswerk . — matteus 24 : 45 - 47 .
+"
+"esegiël het nie diegene gemerk wat behoue sou bly nie .
+"
+"god se volk doen dit ook nie vandag nie .
+"
+"hulle doen eenvoudig die predikingswerk en waarsku ander oor wat in die toekoms sal gebeur .
+"
+"hierdie wêreldwye predikingswerk word met die hulp van die engele gedoen . — openbaring 14 : 6 .
+"
+"diegene wat in esegiël se tyd gered is , het nie ’ n letterlike merk op hulle voorkop gehad nie .
+"
+"in ons tyd sal diegene wat gered gaan word , ook nie ’ n letterlike merk hê nie .
+"
+"wat moet mense doen om die groot verdrukking te oorleef ?
+"
+"wanneer hulle die waarskuwing hoor , moet hulle hulle met die christelike persoonlikheid beklee , hulle aan god toewy en christus se broers ondersteun deur die goeie nuus te verkondig .
+"
+"diegene wat hierdie dinge doen , sal gedurende die groot verdrukking die merk vir oorlewing ontvang .
+"
+"die man met die inkhoring stel jesus voor .
+"
+"gedurende die groot verdrukking sal jesus die groot menigte merk wanneer hy hulle as skape oordeel .
+"
+"dan sal hulle die vooruitsig hê om vir ewig hier op die aarde te lewe . — matteus 25 : 34 , 46 .
+"
+"vandag stel die ses manne met die wapens om mee te verbrysel , die hemelse leërs voor wat deur jesus gelei word .
+"
+"hulle sal binnekort die nasies vernietig en alle goddeloosheid beëindig . — esegiël 10 : 2 , 6 , 7 ; openbaring 19 : 11 - 21 .
+"
+"die lesse wat ons uit hierdie visioen leer , help ons om vol vertroue te wees dat jehovah nie die regverdiges saam met die goddeloses sal vernietig nie .
+"
+"dit herinner ons ook daaraan dat die predikingswerk vandag baie belangrik is .
+"
+"almal moet die waarskuwing hoor voordat die einde kom ! — matteus 24 : 14 .
+"
+"diegene wat wel gered is , soos barug ( jeremia se sekretaris ) , ebed - meleg die etiopiër en die regabiete , het nie ’ n letterlike merk op hulle voorkop gehad nie .
+"
+"die simboliese merk het bloot beteken dat hulle die vernietiging sou oorleef .
+"
+"getroue gesalfdes hoef nie hierdie merk vir oorlewing te ontvang nie .
+"
+"hulle sal óf voordat hulle sterf óf voor die begin van die groot verdrukking hulle finale verseëling ontvang . — openbaring 7 : 1 , 3 .
+"
+"“ luister , o israel : jehovah ons god is een jehovah . ” — deuteronomium 6 : 4 .
+"
+"liedere : 138 , 112
+"
+"hoe kan ons toon dat ons jehovah as “ een jehovah ” aanbid ?
+"
+"wat kan ons doen om ons vrede en eenheid te bewaar ?
+"
+"1 , 2 . ( a ) waarom is die woorde in deuteronomium 6 : 4 so bekend ?
+"
+"( b ) waarom het moses hierdie woorde geuiter ?
+"
+"joodse mense gebruik al honderde jare lank die woorde in deuteronomium 6 : 4 as deel van ’ n spesiale gebed .
+"
+"hulle noem hierdie gebed die sjema , wat die eerste woord van hierdie vers in hebreeus is .
+"
+"baie jode sê hierdie gebed elke dag in die oggend en in die aand op om hulle uitsluitlike toegewydheid aan god te toon .
+"
+"hierdie woorde is deel van moses se laaste toespraak aan die nasie israel .
+"
+"in die jaar 1473 vhj was die nasie in die land moab , gereed om oor die jordaanrivier te trek en die beloofde land in besit te neem .
+"
+"moses het die volk 40 jaar lank gelei , en hy wou hê dat hulle moedig moes wees sodat hulle die uitdagings wat voorgelê het , die hoof kon bied .
+"
+"hulle moes op hulle god , jehovah , vertrou en aan hom getrou bly .
+"
+"moses se laaste woorde aan hulle het hulle aangespoor om juis dit te doen .
+"
+"nadat hy verwys het na die tien gebooie en ander wette van jehovah , het moses die volk die kragtige herinnering gegee wat opgeteken is in deuteronomium 6 : 4 , 5 .
+"
+"die israeliete het geweet dat jehovah hulle god “ een jehovah ” is .
+"
+"getroue israeliete het een god , die god van hulle voorvaders , aanbid .
+"
+"waarom het moses hulle dan daaraan herinner dat jehovah hulle god “ een jehovah ” is ?
+"
+"wat is die verband tussen hierdie waarheid en die feit dat ons ons god met ons hele hart , hele siel en al ons krag liefhet ?
+"
+"en hoe is die woorde in deuteronomium 6 : 4 , 5 vandag op ons van toepassing ?
+"
+"4 , 5 . ( a ) wat is een betekenis van die uitdrukking “ een jehovah ” ?
+"
+"( b ) hoe verskil jehovah van die gode van die nasies ?
+"
+"uniek .
+"
+"die uitdrukking “ een jehovah ” beteken dat jehovah uniek is , dat niemand gelyk is aan hom of soos hy is nie .
+"
+"moses het hierdie uitdrukking blykbaar nie gebruik om te probeer bewys dat geloof in ’ n drie - enige god verkeerd was nie .
+"
+"jehovah is die skepper van die hemel en aarde en die heerser van die heelal .
+"
+"hy is die enigste ware god , en daar is geen ander god soos hy nie .
+"
+"moses se woorde het die israeliete dus daaraan herinner dat hulle slegs jehovah moes aanbid .
+"
+"hulle moes nie die mense rondom hulle , wat talle valse gode en godinne aanbid het , navolg nie .
+"
+"daardie mense het geglo dat hulle gode dele van die natuur kon beheer .
+"
+"die egiptenaars het byvoorbeeld die songod ra , die hemelgodin nut , die aardgod geb , die nylgod hapi sowel as baie diere aanbid .
+"
+"jehovah het getoon dat hy verhewe is bo hierdie valse gode toe hy die tien plae oor egipte gebring het .
+"
+"die hoofgod van kanaän was baäl , ’ n valse god wat as die vrugbaarheidsgod beskou is .
+"
+"daar is ook geglo dat hy die god van die lug , reën en storms is .
+"
+"op baie plekke het mense op baäl vertrou om hulle te beskerm .
+"
+"die israeliete moes onthou dat hulle god , “ die ware god ” , uniek is .
+"
+"hy is “ een jehovah ” . — deuteronomium 4 : 35 , 39 .
+"
+"jehovah god is nie verdeeld of onvoorspelbaar nie .
+"
+"hy is altyd getrou , konsekwent , lojaal en waaragtig
+"
+"wat is nog ’ n betekenis van die woord “ een ” in die uitdrukking “ een jehovah ” , en hoe het jehovah getoon dat hy “ een ” is ?
+"
+"konsekwent en lojaal .
+"
+"die woord “ een ” in die uitdrukking “ een jehovah ” dui ook daarop dat hy altyd betroubaar is en sy beloftes vervul .
+"
+"hy is altyd getrou , konsekwent , lojaal en waaragtig .
+"
+"byvoorbeeld , hy het abraham belowe dat sy nakomelinge die beloofde land sou beërf .
+"
+"en jehovah het talle kragtige wonderwerke verrig om hierdie belofte te hou .
+"
+"vierhonderd - en - dertig jaar nadat jehovah hierdie belofte gemaak het , het sy voorneme steeds nie verander nie . — genesis 12 : 1 , 2 , 7 ; eksodus 12 : 40 , 41 .
+"
+"honderde jare later het jehovah die israeliete sy getuies genoem en vir hulle gesê : “ ek [ is ] dieselfde . . .
+"
+"voor my is geen god geformeer nie , en ná my was daar steeds nie een nie . ”
+"
+"om duidelik te toon dat sy voorneme nooit verander nie , het jehovah ook bygevoeg : “ ek [ is ] altyd dieselfde ” .
+"
+"wat ’ n groot voorreg het die israeliete tog gehad om ’ n god te dien wat konsekwent en altyd lojaal is !
+"
+"vandag het ons dieselfde voorreg . — maleagi 3 : 6 ; jakobus 1 : 17 .
+"
+"8 , 9 . ( a ) wat vereis jehovah van sy aanbidders ?
+"
+"( b ) hoe het jesus die belangrikheid van moses se woorde beklemtoon ?
+"
+"ja , moses het die israeliete daaraan herinner dat jehovah se liefde vir hulle nooit sou verander nie en dat hy altyd vir hulle sou sorg .
+"
+"jehovah het verwag dat hulle hom uitsluitlike toegewydheid moes gee en hom met hulle hele hart , hulle hele siel en al hulle krag moes liefhê .
+"
+"ouers moes elke geleentheid gebruik om hulle kinders van jehovah te leer sodat ook die jonges slegs jehovah sou aanbid . — deuteronomium 6 : 6 - 9 .
+"
+"jehovah verander nooit sy voorneme nie , en daarom sal hy nooit die basiese vereistes vir sy ware aanbidders verander nie .
+"
+"as ons wil hê dat ons aanbidding jehovah moet behaag , moet ons hom uitsluitlike toegewydheid gee en hom met ons hele hart , ons hele verstand en al ons krag liefhê .
+"
+"jesus het gesê dat dit die belangrikste gebod is .
+"
+"( lees markus 12 : 28 - 31 . )
+"
+"kom ons bespreek hoe ons deur ons dade kan toon dat ons glo dat “ jehovah ons god . . . een jehovah ” is .
+"
+"10 , 11 . ( a ) hoe toon ons dat ons slegs jehovah aanbid ?
+"
+"( b ) hoe het jong hebreërs in babilon hulle uitsluitlike toegewydheid aan jehovah getoon ?
+"
+"jehovah is ons enigste god .
+"
+"ons gee hom ons uitsluitlike toegewydheid as ons slegs hom aanbid .
+"
+"ons kan geen ander god aanbid of enige valse idees of gebruike by ons aanbidding van jehovah insluit nie .
+"
+"hy is nie bloot bo ander gode verhewe of magtiger as hulle nie .
+"
+"hy is die ware god .
+"
+"ons moet slegs jehovah aanbid . — lees openbaring 4 : 11 .
+"
+"in die boek daniël lees ons van vier jong hebreërs , naamlik daniël , hananja , misael en asarja .
+"
+"hulle het hulle uitsluitlike toegewydheid aan jehovah getoon toe hulle geweier het om voedsel te eet wat onrein was vir jehovah se aanbidders .
+"
+"en daniël se drie vriende het geweier om hulle voor ’ n afgod , nebukadnesar se goue beeld , neer te buig .
+"
+"hulle het jehovah eerste gestel .
+"
+"hulle was ten volle lojaal aan hom . — daniël 1 : 1 – 3 : 30 .
+"
+"jehovah moet die eerste plek in ons lewe beklee
+"
+"waarteen moet ons waak as ons uitsluitlike toegewydheid aan jehovah wil gee ?
+"
+"jehovah moet die eerste plek in ons lewe beklee .
+"
+"as ons hom ons uitsluitlike toegewydheid wil gee , moet ons versigtig wees dat ander dinge nie sy plek inneem nie .
+"
+"wat is van hierdie dinge ?
+"
+"in die tien gebooie het jehovah gesê dat sy volk nie ander gode mag aanbid nie .
+"
+"hulle moes geen vorm van afgodediens beoefen nie .
+"
+"vandag is daar baie vorme van afgodediens , en party is dalk moeilik om te identifiseer .
+"
+"maar jehovah het nie sy vereistes verander nie .
+"
+"hy is nog steeds “ een jehovah ” .
+"
+"kom ons kyk hoe ons afgodediens vandag kan vermy .
+"
+"waarvoor kan ons liewer word as vir jehovah ?
+"
+"in kolossense 3 : 5 ( lees ) lees ons van dinge wat ons spesiale vriendskap met jehovah kan verwoes .
+"
+"ons sien dat hebsug , dit wil sê gierigheid , met afgodediens verband hou .
+"
+"as ons ’ n sterk begeerte na iets het , soos na baie geld of luukshede , kan dit ons lewe beheers , soos ’ n magtige god .
+"
+"al die sondes wat in kolossense 3 : 5 genoem word , hou verband met gierigheid , ’ n vorm van afgodediens .
+"
+"as ons ’ n sterk begeerte na hierdie dinge het , kan ons liewer daarvoor word as vir god .
+"
+"dan sal jehovah nie meer “ een jehovah ” vir ons wees nie .
+"
+"watter waarskuwing het die apostel johannes gegee in verband met ons liefde vir god ?
+"
+"die apostel johannes het iets soortgelyks beklemtoon .
+"
+"hy het gewaarsku dat iemand wat lief is vir die dinge in die wêreld — “ die begeerte van die vlees en die begeerte van die oë en die spoggerige vertoon van ’ n mens se lewensmiddele ” — nie “ die liefde vir die vader ” in hom het nie .
+"
+"ons moet dus gereeld selfondersoek doen om te sien of ons die wêreld liefhet .
+"
+"ons sal dalk uitvind dat die vermaak , assosiasie , klerestyle en persoonsversorging van die wêreld vir ons aanloklik begin lyk .
+"
+"of ons wil miskien “ groot dinge ” bereik deur middel van hoër onderwys .
+"
+"die nuwe wêreld is baie naby .
+"
+"ons moet dus moses se kragtige woorde onthou !
+"
+"as ons besef en werklik glo dat “ jehovah ons god . . . een jehovah ” is , sal ons hom ons uitsluitlike toegewydheid gee en hom dien op die manier wat vir hom aanneemlik is . — hebreërs 12 : 28 , 29 .
+"
+"waarom het paulus christene daaraan herinner dat god “ een jehovah ” is ?
+"
+"die uitdrukking “ een jehovah ” help ons om te verstaan dat jehovah wil hê dat sy knegte verenig moet wees en dieselfde doel in die lewe moet hê .
+"
+"in die vroeë christengemeente was daar jode , grieke en romeine asook mense van ander nasies .
+"
+"hulle het verskillende agtergronde , gebruike en voorkeure gehad .
+"
+"daarom was dit vir party van hulle moeilik om ’ n nuwe manier van aanbidding te aanvaar of om hulle vorige gebruike te laat staan .
+"
+"paulus moes hulle dus daaraan herinner dat christene een god , jehovah , het . — lees 1 korintiërs 8 : 5 , 6 .
+"
+"jehovah wil hê dat sy knegte verenig moet wees en dieselfde doel in die lewe moet hê
+"
+"16 , 17 . ( a ) watter profesie word in ons dag vervul , en met watter resultaat ?
+"
+"( b ) wat kan ons eenheid ondermyn ?
+"
+"wat van die christengemeente in ons dag ?
+"
+"die profeet jesaja het gesê dat mense van alle nasies “ aan die einde van die dae ” sou saamkom om jehovah te aanbid .
+"
+"hulle sou sê : “ hy sal ons omtrent sy weë onderrig , en ons sal in sy paaie wandel ” .
+"
+"hoe bly is ons tog dat hierdie profesie vandag vervul word !
+"
+"ons broers en susters kom van verskillende plekke , praat verskillende tale en het verskillende kulture .
+"
+"ons is egter verenig in ons aanbidding van jehovah .
+"
+"maar omdat ons so verskillend is , sal ons soms voor uitdagings te staan kom .
+"
+"werk jy hard om die eenheid in die christengemeente te bewaar ?
+"
+"( sien paragraaf 16 - 19 )
+"
+"hoe voel jy byvoorbeeld oor broers en susters van ’ n ander kultuur ?
+"
+"hulle taal , klere , maniere en kos verskil dalk baie van joune .
+"
+"vermy jy hulle en spandeer jy eerder tyd saam met diegene wat ’ n soortgelyke agtergrond as jy het ?
+"
+"hoe voel jy oor die broers wat die leiding neem in jou gemeente — of in jou kring of takkantoor — wat jonger as jy is of wat van ’ n ander ras of kultuur is ?
+"
+"as ons nie versigtig is nie , kan ons toelaat dat hierdie verskille ’ n negatiewe uitwerking op ons het en ons eenheid ondermyn .
+"
+"18 , 19 . ( a ) watter raad vind ons in efesiërs 4 : 1 - 3 ?
+"
+"( b ) wat kan ons doen om die gemeente te help om verenig te bly ?
+"
+"wat kan ons help om nie in hierdie strik te trap nie ?
+"
+"paulus het praktiese raad gegee aan die christene in efese , ’ n ryk stad met mense uit talle verskillende agtergronde .
+"
+"paulus het eienskappe genoem soos ootmoed , oftewel nederigheid , asook sagmoedigheid , lankmoedigheid en liefde .
+"
+"hierdie eienskappe is soos sterk pilare wat ’ n huis staande laat bly .
+"
+"maar om ’ n huis in ’ n goeie toestand te hou , verg ook harde werk .
+"
+"paulus wou hê dat die christene in efese hard moes werk om “ die eenheid van die gees . . . te bewaar ” .
+"
+"ons almal moet ons bes doen om die eenheid van die gemeente te bewaar .
+"
+"eerstens moet ons die eienskappe wat paulus genoem het , aankweek en openbaar , naamlik nederigheid , sagmoedigheid , lankmoedigheid en liefde .
+"
+"tweedens moet ons hard werk om “ die verenigende band van vrede te bewaar ” .
+"
+"misverstande is soos klein krakies in ons eenheid ; ons moet dus hard werk om misverstande op te los sodat ons die vrede en eenheid onder ons kan bewaar .
+"
+"hoe kan ons toon dat ons verstaan dat ‘ jehovah ons god een jehovah is ’ ?
+"
+"“ jehovah ons god is een jehovah . ”
+"
+"dit is ’ n kragtige stelling !
+"
+"hierdie herinnering het die israeliete versterk om uitdagings die hoof te bied toe hulle die beloofde land binnegegaan en in besit geneem het .
+"
+"hierdie woorde kan ons ook versterk om tydens die groot verdrukking te volhard en om by te dra tot die vrede en eenheid in die komende paradys .
+"
+"laat ons voortgaan om jehovah ons uitsluitlike toegewydheid te gee .
+"
+"ons moet hom met ons hele hart , ons hele verstand en al ons krag liefhê en dien , en ons moet hard werk om ons vrede en eenheid te bewaar .
+"
+"as ons aanhou om hierdie dinge te doen , sal jesus ons as skape oordeel , en ons sal sien hoe sy woorde bewaarheid word : “ kom , julle wat deur my vader geseën is , beërf die koninkryk wat van die grondlegging van die wêreld af vir julle berei is . ” — matteus 25 : 34 .
+"
+"ons gee jehovah ons uitsluitlike toegewydheid as ons slegs hom aanbid en hom die eerste plek in ons lewe gee .
+"
+"ons het hom lief met ons hele hart , ons hele verstand en al ons krag
+"
+"daar is baie vissersdorpies langs die kus van trinidad en tobago .
+"
+"jehovah se getuies gesels dikwels met vissermanne wat hulle teëkom
+"
+"waarom is god se organisasie spesiaal ?
+"
+"hoe toon die bybel dat ons almal onvolmaak is ?
+"
+"hoe moet ons ons eie foute en dié van ander beskou ?
+"
+"hoe het die bybel voorspel dat jehovah se volk sal vermeerder ?
+"
+"vandag is daar ’ n wêreldwye organisasie wat bestaan uit mense wat lief is vir jehovah en hom wil dien .
+"
+"alhoewel hulle tekortkominge het en foute maak , rig jehovah hulle deur sy heilige gees .
+"
+"kom ons kyk na ’ n paar maniere waarop jehovah sy volk geseën het .
+"
+"in 1914 het baie min mense jehovah aanbid .
+"
+"maar jehovah het die predikingswerk geseën .
+"
+"gevolglik het miljoene mense bybelwaarhede geleer en sy getuies geword .
+"
+"jehovah het hierdie wonderlike vermeerdering beskryf toe hy gesê het : “ die kleine sal ’ n duisend word , en die geringe ’ n magtige nasie .
+"
+"vandag kan ons duidelik sien dat hierdie profesie vervul is .
+"
+"jehovah se volk is soos ’ n groot nasie .
+"
+"trouens , daar is baie nasies regoor die wêreld wat ’ n bevolking het wat kleiner is as die totale aantal getuies van jehovah .
+"
+"hoe het god se knegte liefde getoon ?
+"
+"gedurende hierdie laaste dae het jehovah sy volk gehelp om hulle liefde vir mekaar te versterk .
+"
+"“ god is liefde ” , en hulle volg hom na .
+"
+"jesus het sy volgelinge beveel om ‘ mekaar lief te hê ’ .
+"
+"hy het ook vir hulle gesê : “ hieraan sal almal weet dat julle my dissipels is , as julle liefde onder mekaar het ” .
+"
+"in onlangse tye het jehovah se knegte hierdie liefde vir mekaar getoon selfs toe nasies oorlog gevoer het .
+"
+"byvoorbeeld , in die tweede wêreldoorlog het omtrent 55 miljoen mense hulle lewe verloor .
+"
+"maar jehovah se volk het niemand in daardie oorlog doodgemaak nie .
+"
+"( lees miga 4 : 1 , 3 . )
+"
+"hulle het dus “ rein . . . van die bloed van alle mense ” gebly . — handelinge 20 : 26 .
+"
+"waarom is die feit dat jehovah se volk in getal toeneem so merkwaardig ?
+"
+"god se volk neem nog steeds toe in getal , selfs al het hulle ’ n magtige vyand , satan .
+"
+"hy is “ die god van hierdie stelsel van dinge ” .
+"
+"satan beheer die politieke organisasies van hierdie wêreld sowel as die nuusmedia , en hy gebruik dit om die verkondiging van die goeie nuus te probeer stopsit .
+"
+"maar hy sal dit nooit regkry nie .
+"
+"satan weet egter dat hy net ’ n kort tydjie oorhet , en daarom hou hy aan om ons te probeer keer om jehovah te aanbid . — openbaring 12 : 12 .
+"
+"waarom sal ander ons gevoelens soms seermaak ?
+"
+"god se knegte leer dat dit baie belangrik is om lief te wees vir god en ander mense .
+"
+"maar die bybel toon dat alle mense van geboorte af onvolmaak is as gevolg van adam se sonde .
+"
+"( lees romeine 5 : 12 , 19 . )
+"
+"party in die gemeente sal dus soms iets sê of doen wat ons gevoelens seermaak .
+"
+"hoe sal ons optree wanneer dit gebeur ?
+"
+"sal ons liefde vir jehovah sterk bly ?
+"
+"sal ons lojaal aan hom en sy volk bly ?
+"
+"die bybel vertel ons van party van god se knegte wat dinge gedoen of gesê het wat ander seergemaak het .
+"
+"kom ons kyk wat ons kan leer uit wat met hulle gebeur het .
+"
+"hoe sou jy gereageer het as jy in die tyd van eli en sy seuns in israel gelewe het ?
+"
+"hoe het eli versuim om sy seuns te dissiplineer ?
+"
+"byvoorbeeld , eli was die hoëpriester van israel , maar sy twee seuns was nie gehoorsaam aan jehovah se wette nie .
+"
+"die bybel sê : “ die seuns van eli was deugniete ; hulle het jehovah nie erken nie ” .
+"
+"eli het geweet dat sy seuns baie slegte dinge doen .
+"
+"maar hy het hulle nie behoorlik gedissiplineer nie .
+"
+"mettertyd het jehovah eli en sy twee seuns gestraf .
+"
+"en later het hy eli se nakomelinge nie meer toegelaat om as hoëpriesters te dien nie .
+"
+"hoe sou jy gereageer het as jy in eli se tyd gelewe het en geweet het dat hy sy seuns toelaat om verskriklike dinge te doen ?
+"
+"sou hierdie situasie jou geloof in jehovah laat verswak het , en sou jy as gevolg daarvan opgehou het om hom te dien ?
+"
+"watter ernstige sonde het dawid gepleeg , en wat het god daaromtrent gedoen ?
+"
+"dawid het wonderlike eienskappe gehad , en daarom was jehovah baie lief vir hom .
+"
+"maar selfs dawid het iets verskrikliks gedoen .
+"
+"toe uria in israel se leër teen die vyand geveg het , het dawid egbreuk gepleeg met uria se vrou , batseba , en sy het swanger geraak .
+"
+"dawid wou nie hê dat iemand moet weet wat hy gedoen het nie .
+"
+"daarom het hy uria beveel om hom te kom spreek . hy het uria toe probeer oortuig om huis toe te gaan .
+"
+"dawid het gehoop dat uria met batseba geslagsomgang sou hê sodat ander sou dink dat uria die pa van die baba is .
+"
+"maar uria wou nie huis toe gaan nie .
+"
+"dawid het toe seker gemaak dat uria in die geveg doodgemaak sou word .
+"
+"dawid en sy familie het baie gely as gevolg van sy ernstige sondes .
+"
+"maar jehovah was barmhartig en het hom vergewe .
+"
+"hy het geweet dat dawid wou doen wat reg is .
+"
+"hoe sou jy gevoel het oor wat dawid gedoen het as jy in daardie tyd gelewe het ?
+"
+"sou jy opgehou het om jehovah te dien ?
+"
+"( a ) hoe het die apostel petrus nie by sy woord gebly nie ?
+"
+"( b ) waarom het jehovah aangehou om petrus te gebruik nadat hy jesus verloën het ?
+"
+"nog ’ n bybelvoorbeeld is die apostel petrus .
+"
+"jesus het hom gekies om ’ n apostel te wees .
+"
+"maar soms het petrus dinge gesê of gedoen wat nie reg was nie .
+"
+"petrus het byvoorbeeld gesê dat hy jesus nooit sal verlaat nie , al verlaat al die ander hom .
+"
+"maar nadat jesus in hegtenis geneem is , het al die apostels , insluitende petrus , hom verlaat .
+"
+"petrus het jesus ook drie keer verloën .
+"
+"maar petrus was baie bedroef oor wat hy gedoen het .
+"
+"daarom het jehovah hom vergewe en aangehou om hom te gebruik .
+"
+"sou jy aangehou het om op jehovah te vertrou as jy ’ n dissipel in daardie tyd was en geweet het wat petrus gedoen het ?
+"
+"ons kan seker wees dat jehovah altyd sal doen wat reg en regverdig is
+"
+"waarom vertrou jy dat god altyd reg en regverdig optree ?
+"
+"uit hierdie voorbeelde sien ons dat sommige van jehovah se knegte verkeerde dinge gedoen het en ander diep seergemaak het .
+"
+"wat sal jy doen as dit vandag gebeur ?
+"
+"sal jy ophou om vergaderinge by te woon of jehovah en sy volk selfs heeltemal verlaat ?
+"
+"of sal jy besef dat jehovah barmhartig is en dat hy miskien wag dat die persoon berou toon ?
+"
+"maar soms sal iemand wat ernstige sondes gepleeg het , nie jammer wees oor wat hy gedoen het nie .
+"
+"sal jy vertrou dat jehovah daarvan weet en dat hy op die regte tyd iets daaromtrent sal doen ?
+"
+"hy sal die persoon dalk selfs uit die gemeente verwyder as dit nodig is .
+"
+"glo jy dat jehovah altyd sal doen wat reg en regverdig is ?
+"
+"hoe het jesus gereageer op judas iskariot en petrus se foute ?
+"
+"ons lees in die bybel van baie mense wat lojaal aan jehovah en sy volk gebly het , al het ander om hulle ernstige foute begaan .
+"
+"jesus het die beste voorbeeld hierin gestel .
+"
+"nadat hy ’ n hele nag in gebed tot sy vader deurgebring het , het hy die 12 apostels gekies .
+"
+"maar een van hulle , judas iskariot , het hom later verraai .
+"
+"en die apostel petrus het jesus verloën .
+"
+"toe party van jesus se dissipels hom teleurgestel het , het hy nie jehovah of die res van die dissipels daarvoor blameer nie .
+"
+"jesus het eerder na aan sy vader gebly en aangehou om hom lojaal te dien .
+"
+"jehovah het hom dus beloon deur hom uit die dood op te wek en hom later as koning van die hemelse koninkryk te kroon . — matteus 28 : 7 , 18 - 20 .
+"
+"wat het die bybel voorspel oor jehovah se knegte in ons dag ?
+"
+"jesus se voorbeeld leer ons om lojaal aan jehovah en sy volk te bly .
+"
+"en ons het goeie redes om sy voorbeeld te volg .
+"
+"ons kan sien dat jehovah sy knegte rig in hierdie tyd van die einde .
+"
+"hy help hulle om die waarheid wêreldwyd te verkondig , en hulle is die enigstes wat hierdie werk doen .
+"
+"hulle is ook gelukkig en waarlik verenig weens al die dinge wat jehovah hulle leer .
+"
+"jehovah het die geestelike toestand van sy volk so beskryf : “ kyk !
+"
+"my knegte sal met vreugde uitroep weens die goeie toestand van die hart . ” — jesaja 65 : 14 .
+"
+"dit sal dwaas en onverstandig wees om jehovah en sy volk te verlaat net omdat iemand ’ n fout gemaak het
+"
+"hoe moet ons ander se foute beskou ?
+"
+"ons is waarlik gelukkig omdat jehovah ons lei en ons help om talle goeie dinge te doen .
+"
+"in teenstelling hiermee is mense in satan se wêreld nie gelukkig nie en het hulle geen ware hoop vir die toekoms nie .
+"
+"hoe dwaas en onverstandig sal dit tog wees om jehovah en sy volk te verlaat net omdat iemand in die gemeente iets gesê of gedoen het wat nie reg is nie !
+"
+"ons moet eerder lojaal aan jehovah bly en sy leiding volg .
+"
+"ons moet ook leer hoe om ander se foute te beskou en hoe om daarop te reageer .
+"
+"13 , 14 . ( a ) waarom moet ons geduldig wees met mekaar ?
+"
+"( b ) watter belofte wil ons onthou ?
+"
+"wat moet jy doen as een van jou broers iets sê of doen wat jou gevoelens seermaak ?
+"
+"die bybel gee hierdie raad : “ moenie haastig wees in jou gees om aanstoot te neem nie , want om aanstoot te neem , rus in die boesem van die sotte ” .
+"
+"ons is almal onvolmaak en maak foute .
+"
+"daarom kan ons nie van ons broers verwag om altyd die regte ding te sê of te doen nie .
+"
+"en dit sal nie goed wees vir ons om oor hulle foute te tob nie .
+"
+"as ons dit doen , sal ons ons vreugde in jehovah se diens verloor .
+"
+"of nog erger , ons geloof in jehovah kan verswak en ons kan selfs sy organisasie verlaat .
+"
+"dan sal ons jehovah nie kan dien nie , en ons sal nie meer die hoop hê om in die nuwe wêreld te lewe nie .
+"
+"wat kan jou dus help om gelukkig te bly in jehovah se diens wanneer ander iets doen wat jou pla ?
+"
+"onthou altyd sy vertroostende belofte : “ kyk , ek skep nuwe hemele en ’ n nuwe aarde ; en die vorige dinge sal nie onthou word nie , en ook sal dit nie in die hart opkom nie ” .
+"
+"jehovah sal jou hierdie seëninge gee as jy lojaal aan hom bly .
+"
+"wat moet ons volgens jesus doen wanneer ander foute maak ?
+"
+"ons is natuurlik nog nie in die nuwe wêreld nie .
+"
+"as iemand ons gevoelens seermaak , moet ons dus nadink oor wat jehovah wil hê ons moet doen .
+"
+"jesus het byvoorbeeld gesê : “ as julle die mense hulle oortredings vergewe , sal julle hemelse vader julle ook vergewe ; maar as julle die mense hulle oortredings nie vergewe nie , sal julle vader julle oortredings ook nie vergewe nie . ”
+"
+"en toe petrus vir jesus gevra het of ons “ tot sewe keer ” moet vergewe , het jesus geantwoord : “ ek sê vir jou : nie ‘ tot sewe keer ’ nie , maar ‘ tot sewe - en - sewentig keer ’ . ”
+"
+"jesus het ons geleer dat ons altyd gewillig moet wees om ander te vergewe . — matteus 6 : 14 , 15 ; 18 : 21 , 22 .
+"
+"watter goeie voorbeeld het josef gestel ?
+"
+"josef se voorbeeld leer ons hoe ons moet reageer wanneer ander ons teleurstel .
+"
+"josef en sy jonger broer was die enigste seuns van jakob en ragel .
+"
+"jakob het tien ander seuns gehad , maar hy het josef die liefste gehad .
+"
+"daarom was hulle baie jaloers op josef .
+"
+"trouens , hulle het hom so gehaat dat hulle hom as ’ n slaaf verkoop het , en hy is na egipte geneem .
+"
+"jare later het die koning van egipte hom die tweede magtigste persoon in die land gemaak omdat hy baie beïndruk was met josef se goeie werk .
+"
+"later het josef se broers na egipte gekom om kos te koop omdat daar ’ n hongersnood was .
+"
+"toe hulle josef sien , het hulle hom nie herken nie , maar hy het geweet wie hulle is .
+"
+"al het hulle hom vroeër sleg behandel , het hy hulle nie gestraf nie .
+"
+"hy het hulle eerder getoets om uit te vind of hulle werklik verander het .
+"
+"toe josef besef dat hulle wel verander het , het hy vir hulle gesê dat hy hulle broer is .
+"
+"later het hy hulle met hierdie woorde vertroos : “ moet dan nou nie bang wees nie .
+"
+"ek sal aanhou om julle en julle kindertjies van voedsel te voorsien . ” — genesis 50 : 21 .
+"
+"wat moet ons doen wanneer ander foute maak ?
+"
+"aangesien almal tekortkominge het , moet jy onthou dat jy ander ook aanstoot kan gee .
+"
+"as jy besef dat jy iemand ontstel het , moet jy dus die bybel se raad volg .
+"
+"vra die persoon om jou te vergewe en probeer om vrede met hom te maak .
+"
+"( lees matteus 5 : 23 , 24 . )
+"
+"ons waardeer dit wanneer ander ons vergewe .
+"
+"daarom moet ons dieselfde vir hulle doen .
+"
+"kolossense 3 : 13 sê vir ons : “ hou aan om mekaar te verdra en mekaar vryelik te vergewe as iemand rede tot klagte teen ’ n ander het .
+"
+"as ons ons broers werklik liefhet , sal ons nie ontsteld bly oor iets wat hulle in die verlede gedoen het nie .
+"
+"en as ons ander vergewe , sal jehovah ons ook vergewe .
+"
+"wanneer ander foute maak , moet ons dus barmhartig teenoor hulle wees net soos ons vader , jehovah , barmhartig teenoor ons is . — lees psalm 103 : 12 - 14 .
+"
+"ons bly lojaal aan jehovah en aan sy volk : wanneer ander foute maak , sal ons nie ophou om vergaderinge by te woon of die gemeente verlaat nie .
+"
+"ons vertrou eerder dat jehovah die gemeente lei en altyd sal doen wat reg is .
+"
+"en net soos jehovah gewillig is om ons te vergewe , is ons gewillig om ander te vergewe
+"
+"mense beskou diamante as baie kosbare edelstene .
+"
+"party is miljoene rande werd .
+"
+"maar is daar iets wat in god se oë kosbaarder is as diamante of ander edelstene ?
+"
+"haykanush , ’ n ongedoopte verkondiger in armenië , het ’ n paspoort naby haar huis opgetel .
+"
+"in die paspoort was ’ n paar debietkaarte en ’ n groot som geld .
+"
+"sy het vir haar man , wat ook ’ n ongedoopte verkondiger is , vertel wat sy gevind het .
+"
+"die egpaar het groot finansiële probleme gehad en was diep in die skuld .
+"
+"maar hulle het besluit om die geld te neem na die adres wat op die paspoort was .
+"
+"die man wat dit verloor het , sowel as sy gesin , was verbaas .
+"
+"haykanush en haar man het verduidelik dat hulle eerlik is omdat hulle die bybel studeer .
+"
+"hulle het toe van die geleentheid gebruik gemaak om die gesin meer van jehovah se getuies te vertel en vir hulle lektuur te gee .
+"
+"die gesin wou vir haykanush ’ n geldelike beloning gee , maar sy wou dit nie aanvaar nie .
+"
+"die volgende dag het die vrou na haykanush en haar man se huis gegaan , en om te toon hoe dankbaar sy is , het sy daarop aangedring dat haykanush ’ n diamantring aanvaar .
+"
+"baie mense sal , net soos daardie gesin , verbaas wees oor haykanush en haar man se eerlikheid .
+"
+"maar was jehovah verbaas ?
+"
+"hoe het hy hulle eerlikheid beskou ?
+"
+"was dit vir hulle die moeite werd om eerlik te wees ?
+"
+"die antwoorde op hierdie vrae is nie moeilik nie .
+"
+"omdat god se knegte weet dat die eienskappe wat hulle in navolging van jehovah openbaar , vir hom kosbaarder is as diamante , goud of ander materiële dinge .
+"
+"ja , die dinge wat jehovah as kosbaar beskou , is nie noodwendig vir alle mense kosbaar nie .
+"
+"maar jehovah se knegte weet van watter groot waarde dit is om sy eienskappe na te volg .
+"
+"kyk byvoorbeeld wat die bybel daaroor sê as ons onderskeidingsvermoë en wysheid verkry .
+"
+"spreuke 3 : 13 - 15 sê : “ gelukkig is die mens wat wysheid gevind het en die mens wat onderskeidingsvermoë verkry , want om dit as gewin te hê , is beter as om silwer as gewin te hê , en om dit as opbrengs te hê , beter as goud .
+"
+"dit is kosbaarder as korale , en al jou ander verlustiginge kan nie daarmee gelykgestel word nie . ”
+"
+"dit is dus duidelik dat hierdie eienskappe vir jehovah kosbaarder is as enige materiële skatte .
+"
+"maar wat van eerlikheid ?
+"
+"jehovah is eerlik .
+"
+"en hy het die apostel paulus geïnspireer om die volgende aan die hebreeuse christene in die eerste eeu te skryf : “ hou aan om vir ons te bid , want ons vertrou dat ons ’ n eerlike gewete het , aangesien ons ons in alles eerlik wil gedra . ” — hebreërs 13 : 18 .
+"
+"jesus christus het ’ n goeie voorbeeld gestel wat eerlikheid betref .
+"
+"byvoorbeeld , toe die hoëpriester kajafas gesê het : “ ek stel jou onder eed by die lewende god om vir ons te sê of jy die christus , die seun van god , is ! ” , was jesus eerlik en het hy erken dat hy die messias is .
+"
+"hy het die waarheid gepraat , al het hy geweet dat die sanhedrin hom van godslastering kon beskuldig en dat dit tot sy teregstelling kon lei . — matteus 26 : 63 - 67 .
+"
+"gestel ons bevind ons in ’ n situasie waar ons materiële voordele kan kry as ons nie al die feite oordra nie of die feite effens verdraai . sal ons eerlik bly ?
+"
+"dit kan moeilik wees om eerlik te bly in hierdie laaste dae waarin baie mense “ liefhebbers van hulleself ” en “ liefhebbers van geld ” is .
+"
+"tydens ’ n finansiële krisis of wanneer dit moeilik is om werk te kry , meen baie dat dit nie verkeerd is om te steel of ander oneerlike dinge te doen nie .
+"
+"baie dink dat ’ n mens oneerlik moet wees as jy materiële voordele wil verkry .
+"
+"selfs party christene het al slegte besluite geneem en hulle goeie naam in die gemeente verloor omdat hulle op ’ n oneerlike manier geld wou maak . — 1 timoteus 3 : 8 ; titus 1 : 7 .
+"
+"maar die meeste christene volg jesus na .
+"
+"hulle besef dat hulle goddelike eienskappe moet openbaar en dat dit baie belangriker is as enige rykdom of voordele .
+"
+"daarom is jong christene nie oneerlik wanneer hulle eksamen skryf nie . ’ n mens ontvang dalk nie altyd , soos haykanush , ’ n beloning as jy eerlik is nie .
+"
+"maar god verwag dat ons eerlik moet wees , en dit help ons om ’ n skoon gewete te hê , iets wat werklik kosbaar is .
+"
+"gagik se voorbeeld toon dat dit die geval is .
+"
+"hy sê : “ voordat ek ’ n christen geword het , het ek vir ’ n groot maatskappy gewerk , maar die eienaar het belasting ontduik deur net ’ n klein gedeelte van die maatskappy se wins te verklaar .
+"
+"daar is van my as die besturende direkteur verwag om ‘ ’ n ooreenkoms ’ te bereik met die belastingagent .
+"
+"ek moes hom omkoop sodat hy sy oë sou sluit vir die maatskappy se oneerlikheid .
+"
+"gevolglik was ek bekend as ’ n oneerlike man . toe ek in die waarheid kom , het ek geweier om daarmee voort te gaan , al het ek ’ n goeie salaris verdien .
+"
+"ek het eerder my eie besigheid begin .
+"
+"van die begin af het ek my maatskappy wetlik geregistreer en al my belasting betaal . ” — 2 korintiërs 8 : 21 .
+"
+"gagik sê : “ omdat ek die helfte minder verdien het as vroeër , was dit ’ n uitdaging om vir my gesin te sorg .
+"
+"maar ek is nou gelukkiger en het ’ n skoon gewete voor jehovah .
+"
+"ek stel ’ n goeie voorbeeld vir my twee seuns , en ek het voorregte in die gemeente gekry .
+"
+"belastingouditeurs en ander met wie ek besigheid doen , weet nou dat ek ’ n eerlike man is . ”
+"
+"jehovah is lief vir diegene wat sy wonderlike eienskappe , insluitende eerlikheid , navolg .
+"
+"hy het koning dawid geïnspireer om ons die volgende versekering te gee : “ ek was eens ’ n jong man , ook het ek oud geword , en tog het ek geen regverdige heeltemal verlate gesien of dat sy nageslag brood soek nie . ” — psalm 37 : 25 .
+"
+"die ondervinding van die getroue rut bewys dit .
+"
+"sy het nie haar bejaarde skoonma , naomi , verlaat nie , maar was eerder lojaal en het by haar gebly .
+"
+"rut het na israel getrek , waar sy die ware god kon aanbid .
+"
+"sy was eerlik en het hard gewerk om oesoorblyfsels in te samel , ’ n voorsiening wat die wet gemaak het vir die armes .
+"
+"en in ooreenstemming met dawid se woorde hierbo , het jehovah rut en naomi nooit verlaat nie .
+"
+"maar jehovah het rut nie net geseën deur materieel vir haar te sorg nie .
+"
+"hy het haar ook gekies om ’ n voorouer te wees van koning dawid en selfs van die beloofde messias ! — rut 4 : 13 - 17 ; matteus 1 : 5 , 16 .
+"
+"dit kan vir party van jehovah se knegte baie moeilik wees om genoeg geld te verdien om in hulle basiese behoeftes te voorsien .
+"
+"eerder as om ’ n maklike maar oneerlike oplossing te vind , is hulle fluks en hardwerkend .
+"
+"sodoende openbaar hulle god se wonderlike eienskappe , insluitende eerlikheid , wat vir hulle baie kosbaarder is as enige materiële dinge . — spreuke 12 : 24 ; efesiërs 4 : 28 .
+"
+"soos rut het christene regoor die wêreld die vertroue dat jehovah hulle sal help .
+"
+"hulle stel geloof in god en sy belofte : “ ek sal jou hoegenaamd nie verlaat of jou ooit versaak nie ” .
+"
+"jehovah het keer op keer getoon dat hy diegene wat te alle tye eerlik is , kan en sal help .
+"
+"hy het nog altyd sy belofte gehou om in die basiese behoeftes van sy knegte te voorsien . — matteus 6 : 33 .
+"
+"ja , mense beskou diamante en ander materiële dinge dalk as kosbaar .
+"
+"maar ons kan daarvan seker wees dat ons eerlikheid en ander goeie eienskappe vir ons hemelse vader baie kosbaarder is as enige edelsteen !
+"
+"as ons eerlik is , het ons ’ n skoon gewete en vryheid van spraak in die bediening
+"

--- a/en-af/jw300-baseline/test.en
+++ b/en-af/jw300-baseline/test.en
@@ -1,0 +1,2001 @@
+source_sentence
+"when we read the bible and our publications , we need to meditate on how the information can help us personally
+"
+"a young girl talks with her schoolmates about the good news and offers them a tract .
+"
+"she lives in the town of ho in the volta region of ghana
+"
+"“ keep perceiving what the will of jehovah is . ” ​ — ephesians 5 : 17 .
+"
+"songs : 69 , 57
+"
+"how can our decisions affect us and others ?
+"
+"when the bible does not give us a specific law , how can we know what would please jehovah ?
+"
+"how can we get to know more about the way jehovah thinks ?
+"
+"what are some examples of bible laws , and how does obeying them benefit us ?
+"
+"in the bible , jehovah has given us laws that clearly tell us what he wants us to do .
+"
+"for example , he tells us that we must not worship idols , steal , get drunk , or do things that are sexually immoral .
+"
+"and jehovah’s son , jesus , gave this specific command to his followers : “ make disciples of people of all the nations , baptizing them in the name of the father and of the son and of the holy spirit , teaching them to observe all the things i have commanded you .
+"
+"everything that jehovah and jesus tell us to do is for our own good .
+"
+"jehovah’s laws teach us how to look after ourselves and our families and help us to have better health and to be happy .
+"
+"more important , when we obey jehovah’s commands , including the command to preach , he is pleased with us and he blesses us .
+"
+"2 , 3 . ( a ) why does the bible not give us rules for every situation in life ?
+"
+"at the same time , the bible does not give us rules about every situation in life .
+"
+"for example , we do not find specific instructions in the bible on what we should wear .
+"
+"this shows how wise jehovah is .
+"
+"even though fashion keeps changing over time and people around the world wear different styles of clothes , the bible is never out - of - date .
+"
+"also , it does not contain a lot of rules about what jobs or entertainment we should choose or exactly what we should do to stay healthy .
+"
+"jehovah allows individuals and family heads to make decisions about these things .
+"
+"so when we have to make an important decision that will affect our life and we find no law about it in the bible , we might wonder : ‘ is jehovah interested in the decision i make ?
+"
+"will he be pleased with whatever i choose to do as long as i do not break a law in the bible ?
+"
+"how can i be sure that he will be happy with the choices i make ? ’
+"
+"some people feel that they can do whatever they want to do .
+"
+"but we want to do what makes jehovah happy .
+"
+"so before we make a decision , we need to think about what the bible says and then obey it .
+"
+"for example , the bible tells us how god feels about the use of blood , so we follow what it says .
+"
+"we can pray to jehovah to help us make decisions that will please him .
+"
+"our decisions affect us . a good decision can help us draw closer to jehovah . a bad decision could damage our friendship with him .
+"
+"our decisions can also affect other people .
+"
+"we do not want to do anything that might upset our brothers or weaken their faith .
+"
+"we also do not want to cause problems between brothers in the congregation .
+"
+"so it is important for us to make good decisions . ​ — read romans 14 : 19 ; galatians 6 : 7 .
+"
+"what should guide our decisions ?
+"
+"when the bible does not tell us exactly what we should do , how can we make good decisions ?
+"
+"instead of just doing what we prefer , we must think carefully about our own situation and make a decision that will please jehovah .
+"
+"then we can be sure that he will help us to have good results . ​ — read psalm 37 : 5 .
+"
+"where there is no bible law , how can we find out what jehovah would want us to do in a certain situation ?
+"
+"but how can we know what will please jehovah ?
+"
+"ephesians 5 : 17 tells us : “ keep perceiving what the will of jehovah is . ”
+"
+"when there is no specific law in the bible , we need to perceive , or understand , what jehovah wants us to do in our situation .
+"
+"we need to pray to him and allow his holy spirit to guide us .
+"
+"how did jesus perceive what jehovah wanted him to do ?
+"
+"jesus always perceived what jehovah wanted him to do .
+"
+"for example , twice when the crowds were hungry , jesus prayed and then fed them by means of a miracle .
+"
+"but when he got hungry in the wilderness and the devil wanted him to change stones into bread , jesus refused .
+"
+"( read matthew 4 : 2 - 4 . )
+"
+"he knew his father very well , so he knew that jehovah would not want him to use holy spirit for his own needs .
+"
+"he was sure that his father would guide him and give him food when he needed it .
+"
+"like jesus , we can make good decisions if we rely on jehovah to guide us .
+"
+"in all your ways take notice of him , and he will make your paths straight .
+"
+"fear jehovah and turn away from bad . ”
+"
+"when we study the bible and learn about the way jehovah thinks , we will understand what he wants us to do in a specific situation .
+"
+"and the more we learn about the way jehovah thinks , the easier it will be for us to make decisions that will please him .
+"
+"in this way , we become more “ sensitive to god’s guidance . ” ​ — ezekiel 11 : 19 , footnote .
+"
+"imagine that a married woman is shopping and sees a lovely pair of shoes .
+"
+"but they are very expensive .
+"
+"although her husband is not with her , she knows what he would think if she spent that much money .
+"
+"how does she know ?
+"
+"she has been married to him for some time , so she knows how he wants them to use the money they have .
+"
+"in a similar way , when we learn about the way jehovah thinks and what he has done in the past , we will know what he would want us to do in different situations .
+"
+"what questions can we ask ourselves when we read or study the bible ?
+"
+"( see the box “ when you study the bible , ask yourself . ” )
+"
+"how can we find out what jehovah thinks ?
+"
+"the most important thing we can do is to read and study the bible regularly .
+"
+"while we are doing this , we could ask ourselves : ‘ what does this teach me about jehovah ?
+"
+"why did he act this way ? ’
+"
+"and like david , we also need to ask jehovah to help us know him better .
+"
+"david wrote : “ make me know your ways , o jehovah ; teach me your paths .
+"
+"cause me to walk in your truth and teach me , for you are my god of salvation .
+"
+"in you i hope all day long . ”
+"
+"when we learn something about jehovah , we can think of situations where we can use that information .
+"
+"could we use it in the family , at work , at school , or in the ministry ?
+"
+"when we think of a specific situation , it will be easier to know how jehovah would want us to use the information .
+"
+"to find out what jehovah thinks , we should read and study the bible regularly
+"
+"how can our publications and meetings help us to get to know what jehovah thinks about various matters ?
+"
+"another way to get to know the way jehovah thinks is to pay close attention to what his organization teaches us from the bible .
+"
+"for example , when we have a decision to make , the watch tower publications index and the research guide for jehovah’s witnesses can help us find out what jehovah thinks .
+"
+"we can also benefit from our christian meetings when we listen carefully and comment and when we meditate on what is being taught .
+"
+"this will help us learn to think the way jehovah does .
+"
+"as a result , we will be able to make decisions that will please him and that he will bless .
+"
+"give an example of how we can make a wise decision when we consider what jehovah thinks .
+"
+"let us take a look at an example of how we can make a wise decision when we consider what jehovah thinks .
+"
+"perhaps you would like to pioneer .
+"
+"you have made some changes in your life so that you can spend more time in the ministry .
+"
+"but you are still not sure whether you will really be happy with less money and fewer things .
+"
+"of course , the bible does not say that we have to pioneer to serve jehovah .
+"
+"we could continue to serve him faithfully as publishers .
+"
+"but on the other hand , jesus said that jehovah blesses those who make sacrifices for the kingdom .
+"
+"( read luke 18 : 29 , 30 . )
+"
+"the bible also says that jehovah is pleased when we do all we can to praise him , and he wants us to be happy serving him .
+"
+"by praying about these things and meditating on them , we can make a decision that is practical in our situation and one that jehovah will bless .
+"
+"how can you determine if a certain style of clothing is pleasing to jehovah ?
+"
+"here is another example : you really like a certain style of clothing , but you know that some in the congregation might be offended if you wear those clothes .
+"
+"the bible does not say anything about that specific style .
+"
+"so how can you know what jehovah thinks ?
+"
+"the bible tells us : “ the women should adorn themselves in appropriate dress , with modesty and soundness of mind , not with styles of hair braiding and gold or pearls or very expensive clothing , but in the way that is proper for women professing devotion to god , namely , through good works . ”
+"
+"of course , all of jehovah’s servants , including men , can learn from these words .
+"
+"when we are modest , we think of how others might feel about the clothes we choose to wear .
+"
+"and because we love our brothers , we avoid upsetting or offending them .
+"
+"if we consider what the bible says and how jehovah thinks , we can make decisions that he will be pleased with .
+"
+"15 , 16 . ( a ) how does jehovah feel if we keep on thinking about sexually immoral things ?
+"
+"( b ) when we are choosing entertainment , how can we know what is pleasing to jehovah ?
+"
+"( c ) how should weighty decisions be made ?
+"
+"from the bible , we learn that jehovah feels deeply hurt and sad when people do wicked things and when they think about bad things .
+"
+"( read genesis 6 : 5 , 6 . )
+"
+"it is clear that jehovah does not want us to daydream about sexually immoral things .
+"
+"in fact , if we keep thinking about these things , we may actually do them .
+"
+"instead , jehovah wants us to think about pure and good things .
+"
+"the disciple james wrote that jehovah’s wisdom “ is first of all pure , then peaceable , reasonable , ready to obey , full of mercy and good fruits , impartial , not hypocritical . ”
+"
+"so the bible teaches us that we must avoid any entertainment that could cause us to imagine or desire unclean and bad things .
+"
+"and if we understand clearly what jehovah loves and what he hates , it will be easy for us to know which books , movies , or games to choose .
+"
+"we will not need to ask others what we should do .
+"
+"when we have a decision to make , there are often several options we can choose from that would all please jehovah .
+"
+"but when we need to make a very important decision , it may be good to ask an elder or another experienced brother or sister to give us some advice .
+"
+"of course , we should not ask that person to make a decision for us .
+"
+"instead , we need to think carefully about what we know from the bible and then make our own decision .
+"
+"the apostle paul said : “ each one will carry his own load of responsibility . ” ​ — galatians 6 : 5 , footnote .
+"
+"how do we benefit from making decisions that please jehovah ?
+"
+"when we make decisions that please jehovah , we draw closer to him and have his approval and blessing .
+"
+"then our faith in jehovah becomes stronger .
+"
+"so let us meditate on what we read in the bible so that we can understand how he thinks .
+"
+"of course , we will always have something new to learn about jehovah .
+"
+"but if we work hard to learn about him now , we will become wise and will be able to make good decisions .
+"
+"the ideas and plans of humans change , but jehovah never changes .
+"
+"the psalmist said : “ the decisions of jehovah will stand forever ; the thoughts of his heart are from generation to generation . ”
+"
+"clearly , we can make the best decisions when we learn to think the way jehovah thinks and then do what is pleasing to him .
+"
+"what does this teach me about jehovah ?
+"
+"how can i use this information . . .
+"
+"at home ?
+"
+"at work ?
+"
+"at school ?
+"
+"to perceive jehovah’s will : to find out , or understand , what jehovah thinks and what pleases him .
+"
+"this is especially important when there is no specific command in the bible .
+"
+"we need to pray and meditate on what we have learned about jehovah , what he loves and hates , and what he has done in the past
+"
+"“ be transformed by making your mind over . ” ​ — romans 12 : 2 .
+"
+"songs : 61 , 52
+"
+"after baptism , why should we keep making changes ?
+"
+"why does god expect us to put forth effort to overcome our weaknesses ?
+"
+"what can we do to let god’s word keep on changing our life ?
+"
+"1 - 3 . ( a ) what changes may it be hard for us to make after our baptism ?
+"
+"( b ) when making progress is harder than we expected , what questions might we ask ?
+"
+"for many years , kevin gambled , smoked , drank too much , and took drugs .
+"
+"then he learned about jehovah and wanted to be his friend .
+"
+"but to do so , he had to make big changes in his life .
+"
+"he was able to change by means of jehovah’s help and the power of his word , the bible . ​ — hebrews 4 : 12 .
+"
+"after kevin got baptized , he still had to make changes to his personality so that he could become a better christian .
+"
+"for example , he used to get angry quickly .
+"
+"in fact , kevin said that learning to control his temper was actually harder than it was to stop the bad things he was doing before he got baptized !
+"
+"but he was able to make changes by begging jehovah to help him and by a thorough study of the bible .
+"
+"before we got baptized , many of us had to make big changes in our lives so that we could live in the way the bible says we should .
+"
+"but even now , we realize that there are smaller changes we need to make to become more like god and christ .
+"
+"for example , we might notice that we complain a lot or that we often gossip and say unkind things about others .
+"
+"or at times we may be so afraid of what others might think or say that we do not do what is right .
+"
+"perhaps we have been trying to change for many years but we still keep making the same mistakes .
+"
+"so we may wonder : ‘ why is it so difficult for me to make these smaller changes ?
+"
+"what must i do to apply what the bible says so that i can continue to improve my personality ? ’
+"
+"why are we unable to please jehovah in everything we do ?
+"
+"we love jehovah , and we desire with all our heart to please him .
+"
+"but sadly , we cannot please him all the time , because we are imperfect .
+"
+"we often feel like the apostle paul , who said : “ i have the desire to do what is fine but not the ability to carry it out . ” ​ — romans 7 : 18 ; james 3 : 2 .
+"
+"what changes did we make before we got baptized , but what weaknesses may we still struggle with ?
+"
+"before we could be part of the congregation , we had to stop practicing things that jehovah hates .
+"
+"but we are still imperfect .
+"
+"so we continue to make mistakes even if we have been baptized for many years .
+"
+"from time to time , we may have wrong desires and feelings , or we may find it hard to control a weakness in our personality .
+"
+"in fact , we may have to fight the same weakness for many years .
+"
+"6 , 7 . ( a ) what makes it possible for us to be jehovah’s friends even though we are imperfect ?
+"
+"( b ) why should we not hold back from asking jehovah for forgiveness ?
+"
+"even though we are imperfect , we can still have a friendship with jehovah and serve him .
+"
+"always remember how you first became jehovah’s friend .
+"
+"he was the one who saw the good in you and wanted you to know him .
+"
+"he also knew that you had faults and weaknesses and that you were going to make mistakes .
+"
+"but jehovah still wanted you to be his friend .
+"
+"jehovah loved us so much that he gave us a precious gift .
+"
+"he sent his son to earth so that jesus could give his life as a ransom for our sins .
+"
+"when we make a mistake , we can ask jehovah for forgiveness .
+"
+"and because of the ransom , we can be sure that he will forgive us and that we will still be his friends .
+"
+"remember , jesus died for repentant sinners .
+"
+"so even if we feel that what we have done is very bad , we must never stop praying to jehovah for forgiveness .
+"
+"if we did not ask him to forgive us , it would be like refusing to wash our hands when they are dirty .
+"
+"how grateful we are that jehovah has made it possible for us to be his friends even though we are imperfect ! ​ — read 1 timothy 1 : 15 .
+"
+"if we want to draw closer to jehovah , we must keep trying to imitate him and his son
+"
+"why should we not ignore our weaknesses ?
+"
+"of course , we cannot ignore our weaknesses or keep making excuses for them .
+"
+"jehovah has told us what kind of people he wants his friends to be .
+"
+"so if we want to draw closer to him , we must keep trying to imitate him and his son .
+"
+"we must also try to control our wrong desires , and we may even be able to get rid of some of them .
+"
+"no matter how long we have been baptized , we must keep improving our personality . ​ — 2 corinthians 13 : 11 .
+"
+"how do we know that we can keep putting on the new personality ?
+"
+"the apostle paul told christians : “ you were taught to put away the old personality that conforms to your former course of conduct and that is being corrupted according to its deceptive desires . and you should continue to be made new in your dominant mental attitude , and should put on the new personality that was created according to god’s will in true righteousness and loyalty . ”
+"
+"this means that we need to keep on making the effort to change and “ put on the new personality . ”
+"
+"so no matter how long we have been serving jehovah , we can always learn more about his qualities .
+"
+"and the bible can help us to keep making changes in our personality to become more like him .
+"
+"what must we do to keep making changes with the help of the bible , and what questions might we ask ?
+"
+"we all want to follow what the bible says .
+"
+"but we need to work hard if we want to continue to change .
+"
+"why do we need to make such an effort ?
+"
+"could not jehovah just make it easy for us to do what is right ?
+"
+"why does jehovah expect us to put forth effort to overcome our weaknesses ?
+"
+"when we think of the universe and all that is in it , we have no doubt that jehovah has the power to do anything .
+"
+"for example , he made the sun , which is extremely powerful .
+"
+"every second , the sun produces a huge amount of light and heat , yet only a small amount of this energy is needed for life on earth to exist .
+"
+"jehovah also gives power to his servants on earth when they need it .
+"
+"clearly , if jehovah wanted to , he could make it very easy for us to fight our weaknesses and to stop having wrong desires .
+"
+"so why does he not do so ?
+"
+"jehovah has given us free will .
+"
+"he allows us to choose for ourselves whether we will obey him or not .
+"
+"when we choose to obey him and work hard to do his will , we show that we love him and want to please him .
+"
+"satan says that jehovah has no right to rule .
+"
+"but when we obey jehovah , we show that we want him to be our ruler .
+"
+"and we can be sure that our loving father values every effort we make to obey him .
+"
+"when we work hard to control our weaknesses even though it is not easy to do so , we are loyal to jehovah and show that we want him to be our ruler .
+"
+"jehovah tells us that we should work hard to imitate his qualities .
+"
+"what can we do to develop qualities that jehovah loves ?
+"
+"( see the box “ the bible and prayer changed their lives . ” )
+"
+"instead of just deciding for ourselves what we need to change , we need to let god guide us .
+"
+"romans 12 : 2 says : “ stop being molded by this system of things , but be transformed by making your mind over , so that you may prove to yourselves the good and acceptable and perfect will of god . ”
+"
+"so to find out what jehovah wants , we need to rely on the help that he has provided .
+"
+"we must read the bible daily , meditate on what we read , and pray to jehovah to give us his holy spirit .
+"
+"in these ways , jehovah can help us to understand what pleases him , and we can learn to think the way he does .
+"
+"as a result , what we think , say , and do will be more pleasing to jehovah , and we will learn how to control our weaknesses .
+"
+"but even then , we will need to keep fighting them . ​ — proverbs 4 : 23 .
+"
+"collect articles from our publications or scriptures from the bible that help you fight your weaknesses , and read them again from time to time ( see paragraph 15 )
+"
+"in addition to reading the bible every day , we need to study it with the help of our publications , such as the watchtower and awake !
+"
+"many articles in these magazines teach us how we can imitate jehovah’s qualities and how to fight our weaknesses .
+"
+"we may find certain articles or scriptures that are especially helpful to us .
+"
+"we can collect these scriptures and articles so that we can read them again from time to time .
+"
+"why should we not be discouraged if we are not able to make changes quickly ?
+"
+"it takes time to learn to imitate jehovah’s qualities .
+"
+"so if you feel that you have not made as many changes as you would like to , be patient .
+"
+"at first , you may need to force yourself to do what the bible says .
+"
+"but the more you think and behave the way jehovah wants you to , the easier it will become for you to think the way he does and to do what is right . ​ — psalm 37 : 31 ; proverbs 23 : 12 ; galatians 5 : 16 , 17 .
+"
+"if we are loyal to jehovah , what delightful future can we look forward to ?
+"
+"we look forward to the time when we will be perfect and serve jehovah forever .
+"
+"at that time , we will not need to fight any weaknesses , and it will be much easier for us to imitate jehovah .
+"
+"but even now we are able to worship jehovah because he has given us the gift of the ransom .
+"
+"although we are imperfect , we can please him if we continue to work hard to make changes and follow what he teaches us in the bible .
+"
+"how can we be sure that the bible has power to continue changing our life ?
+"
+"kevin did all he could to learn to control his anger .
+"
+"he meditated on what he read in the bible and tried hard to make changes in his life .
+"
+"he also followed the advice that fellow christians gave him .
+"
+"although it took a few years for kevin to improve , in time he was able to serve as a ministerial servant .
+"
+"and for the last 20 years , he has been serving as an elder .
+"
+"but even now , he knows that he needs to continue fighting his weaknesses .
+"
+"like kevin , we can keep improving our personality .
+"
+"if we do , we will continue to draw closer to jehovah .
+"
+"and when we do all we can to make changes to please him , he will help us to succeed .
+"
+"we can be sure that with the help of the bible , we can keep making changes in our lives . ​ — psalm 34 : 8 .
+"
+"[ 1 ] ( paragraph 1 ) the name has been changed .
+"
+"russell often complained about other brothers and sisters and thought that most of the time they did not do anything right .
+"
+"maria victoria loved to gossip .
+"
+"linda was afraid of what others might think or say whenever she went out in the ministry .
+"
+"although all three were baptized christians , they thought it would be impossible to change .
+"
+"russell : “ supplicating jehovah in prayer and a daily dose of bible reading helped me .
+"
+"meditating on 2 peter 2 : 11 and on personal counsel from the elders made a big difference . ”
+"
+"maria victoria : “ i fervently prayed to jehovah to help me control my tongue .
+"
+"i also saw the need to stop having close association with people who loved to gossip .
+"
+"psalm 64 : 1 - 4 made me realize that i did not want to be one from whom others pray to be safeguarded !
+"
+"i also came to appreciate that continuing to gossip would make me a poor example and bring reproach on jehovah’s name . ”
+"
+"linda : “ i familiarized myself with our tracts so as to be prepared to offer them .
+"
+"associating with those who enjoy various avenues of service has been a great help .
+"
+"and i continue to rely on jehovah through prayer . ”
+"
+"we fight our weaknesses : we may have weaknesses that are not easy to control , or we may make the same mistakes again and again .
+"
+"for example , we may be impatient , lose our temper easily , or complain a lot about others .
+"
+"we need to keep trying hard to correct our weaknesses because we know that this will please jehovah .
+"
+"3 appreciating jehovah as our potter
+"
+"9 do you let the great potter mold you ?
+"
+"a potter is a craftsman who molds clay by hand to create beautiful vessels .
+"
+"in these two articles , we will see why we can say that jehovah is “ our potter ” and what we need to do in order to be like soft clay in his hands .
+"
+"15 “ jehovah our god is one jehovah ”
+"
+"what does it mean that jehovah our god is “ one jehovah ” ?
+"
+"how does that affect our relationship with him and with our brothers and sisters ?
+"
+"since we come from different backgrounds , we need to understand what jehovah requires of us so that he can be “ our god . ”
+"
+"21 do not let the faults of others stumble you
+"
+"all humans have faults that can hurt others .
+"
+"so how should we react when someone says or does something that hurts our feelings ?
+"
+"in this article , we will discuss bible examples that can help us .
+"
+"27 a godly quality more precious than diamonds
+"
+"“ o jehovah , . . . you are our potter ; we are all the work of your hand . ” ​ — isaiah 64 : 8 .
+"
+"songs : 89 , 26
+"
+"how jehovah chooses those whom he will mold ?
+"
+"why jehovah molds his people ?
+"
+"how god molds those who submit to him ?
+"
+"why is jehovah the greatest potter ?
+"
+"in november 2010 , a bid of nearly 70 million dollars was made on a chinese clay vase in england .
+"
+"it is amazing that a potter can mold something as common and cheap as clay into a beautiful and expensive vase .
+"
+"jehovah , our potter , is far greater than any human potter .
+"
+"the bible says that jehovah made a perfect man “ out of dust from the ground , ” that is , out of clay .
+"
+"that man , adam , was a “ son of god ” and was created with the ability to imitate god’s qualities . ​ — luke 3 : 38 .
+"
+"how can we imitate the attitude of repentant israelites ?
+"
+"when adam rebelled against his creator , he was no longer a son of god .
+"
+"but many of adam’s descendants have chosen jehovah as their ruler .
+"
+"by humbly obeying their creator , they have shown that they want him , not satan , to be their father and potter .
+"
+"their loyalty to god reminds us of what the repentant israelites said : “ o jehovah , you are our father .
+"
+"we are the clay , and you are our potter ; we are all the work of your hand . ” ​ — isaiah 64 : 8 .
+"
+"jehovah’s true worshippers today likewise try hard to be humble and obedient .
+"
+"they consider it an honor to call jehovah their father , and they want him to be their potter .
+"
+"are we willing to be like soft clay that god can mold into a precious vessel ?
+"
+"do we see each of our brothers and sisters as a work in progress , still being molded by god ?
+"
+"to help us have the right attitude , we will discuss how jehovah chooses those whom he molds , why he molds them , and how he does that .
+"
+"how does jehovah choose those whom he draws to himself ?
+"
+"jehovah does not look at people the way we do .
+"
+"instead , he examines the heart and sees who each of us really is .
+"
+"( read 1 samuel 16 : 7b . )
+"
+"jehovah demonstrated this when he formed the christian congregation .
+"
+"he drew to himself and to his son many people whom some might consider to be worthless .
+"
+"for example , one such person was the pharisee named saul , “ a blasphemer and a persecutor and an insolent man . ”
+"
+"but jehovah examined saul’s heart and did not feel that he was useless clay .
+"
+"instead , jehovah saw that saul could be molded into “ a chosen vessel ” who would preach “ to the nations as well as to kings and the sons of israel . ”
+"
+"jehovah also chose others who could be molded “ for an honorable use , ” including former drunkards , immoral people , and thieves .
+"
+"as they studied the scriptures , they strengthened their faith in jehovah and allowed him to mold them .
+"
+"it is not up to us to judge people in our territory or in our congregation
+"
+"how should our trust in jehovah as our potter affect our attitude toward ( a ) the people in our territory ?
+"
+"( b ) our brothers and sisters ?
+"
+"we trust that jehovah is able to choose and draw the right people .
+"
+"that is why we should not judge others in our territory or in our congregation .
+"
+"see , for example , how a man called michael reacted when jehovah’s witnesses visited him .
+"
+"he says : “ i would just turn away and ignore them as if they did not exist .
+"
+"i was really rude !
+"
+"later , in a different setting , i met a family whom i admired because of their good conduct .
+"
+"then one day i received a shock ​ — they were jehovah’s witnesses !
+"
+"their behavior moved me to examine the basis for my prejudice .
+"
+"i soon came to the realization that my attitude was based on ignorance and hearsay , not on facts . ”
+"
+"michael wanted to learn more and accepted a bible study .
+"
+"later he got baptized and then became a full - time servant .
+"
+"when we recognize jehovah as our potter , our attitude toward our brothers and sisters will also change .
+"
+"we will see each of them as a work in progress .
+"
+"this is how jehovah sees them .
+"
+"he sees who they truly are inside and knows that their imperfection is only temporary .
+"
+"he also knows what kind of person each of them can become .
+"
+"we can imitate jehovah if we have the same positive attitude toward our brothers .
+"
+"we can even work with our potter to help our brothers and sisters make progress .
+"
+"the elders in the congregation should set a good example in doing that . ​ — ephesians 4 : 8 , 11 - 13 .
+"
+"why do you appreciate jehovah’s discipline ?
+"
+"some people may say : ‘ i never fully valued the discipline i received from my parents until i had children of my own . ’
+"
+"as we grow older , we may come to value discipline because we see it as an expression of love .
+"
+"( read hebrews 12 : 5 , 6 , 11 . )
+"
+"yes , jehovah loves us as his children , which is why he patiently disciplines us , or molds us .
+"
+"he wants us to be wise and happy and to love him as our father .
+"
+"he does not like to see us suffer , and he does not want us to die as unrepentant sinners . ​ — ephesians 2 : 2 , 3 .
+"
+"jehovah loves us as his children , which is why he patiently disciplines us , or molds us
+"
+"how is jehovah teaching us today , and how will this education continue in the future ?
+"
+"before we came to know jehovah , we may have had many bad qualities .
+"
+"but jehovah molded us and helped us to change , and as a result , we now have some beautiful qualities .
+"
+"we live in a spiritual paradise .
+"
+"this is the special environment that jehovah is creating in our day that helps to mold us .
+"
+"in it , we feel safe and secure even though the world around us is wicked .
+"
+"those who grew up without feeling love in their family now feel real love from their brothers and sisters in the spiritual paradise .
+"
+"and we have learned to show love to others .
+"
+"but most important , we have come to know jehovah and now feel his fatherly love . ​ — james 4 : 8 .
+"
+"in the new world , we will fully benefit from the spiritual paradise .
+"
+"we will also enjoy life in a physical paradise ruled by god’s kingdom .
+"
+"during that time , jehovah will continue to mold us and educate us in a way that is hard to imagine right now .
+"
+"jehovah will also make our minds and bodies perfect .
+"
+"this will make it easier for us to understand and completely obey his instructions .
+"
+"so let us continue to allow jehovah to mold us , and let us show him that we value this proof of his love for us . ​ — proverbs 3 : 11 , 12 .
+"
+"how did jesus reflect the great potter’s patience and skill ?
+"
+"just as a skilled potter knows the type of clay he is molding , our potter , jehovah , knows us very well .
+"
+"he knows our weaknesses , our limitations , and the progress we have made , and he molds each one of us with these circumstances in mind .
+"
+"( read psalm 103 : 10 - 14 . )
+"
+"we can learn how jehovah views us by looking at how jesus reacted to the imperfections of his apostles .
+"
+"at times , the apostles argued about who was the greatest .
+"
+"if you had been there , how would you have viewed the apostles ’ conduct ?
+"
+"you might have felt that they were not like soft clay .
+"
+"jesus , however , knew that they could be molded if they listened to his kind and patient counsel and if they imitated his humility .
+"
+"after jesus ’ resurrection , the apostles received god’s spirit and were no longer focused on who was the greatest .
+"
+"instead , they were focused on the work jesus gave them . ​ — acts 5 : 42 .
+"
+"in what ways did david prove to be like soft clay , and how can we imitate him ?
+"
+"today , jehovah uses the bible , his holy spirit , and the congregation to mold us .
+"
+"how can the bible mold us ?
+"
+"we need to read it , meditate on what we read , and ask jehovah to help us apply what we have learned .
+"
+"king david wrote : “ i remember you while upon my bed ; i meditate on you during the watches of the night . ”
+"
+"he also wrote : “ i will praise jehovah , who has given me advice .
+"
+"yes , david meditated on jehovah’s counsel and let it mold his deepest thoughts and feelings , even when the counsel was difficult to accept .
+"
+"david set a beautiful example of humility and obedience for us .
+"
+"so ask yourself : ‘ when i read the bible , do i meditate on it and let god’s counsel touch my deepest thoughts and feelings ?
+"
+"can i do so even more ? ’ ​ — psalm 1 : 2 , 3 .
+"
+"how does jehovah mold us by means of holy spirit and the christian congregation ?
+"
+"holy spirit can mold us in several ways .
+"
+"for example , it can help us learn to imitate jesus ’ personality and to display the different aspects of the fruitage of the spirit .
+"
+"one aspect of that fruitage is love .
+"
+"we love god and want to obey him and be molded by him because we know that his commandments are for our benefit .
+"
+"in addition , holy spirit can give us the strength to avoid being molded by this wicked world .
+"
+"when the apostle paul was young , he was influenced by the proud jewish religious leaders .
+"
+"but holy spirit helped him to change .
+"
+"he later wrote : “ for all things i have the strength through the one who gives me power . ”
+"
+"we too need to ask for holy spirit , knowing that jehovah will answer our sincere prayers . ​ — psalm 10 : 17 .
+"
+"jehovah uses christian elders to mold us , but we must apply their counsel ( see paragraphs 12 , 13 )
+"
+"jehovah also uses the congregation and the elders to mold each one of us .
+"
+"for example , if the elders notice that we have a weakness , they try to help us .
+"
+"however , they do not give counsel based on their own ideas .
+"
+"instead , they humbly pray to jehovah for understanding and wisdom .
+"
+"then , they do research using the bible and our christian publications in order to find information that will help us .
+"
+"if the elders come to you and give you kind and loving counsel , perhaps about how you are dressed , remember that this is proof of god’s love for you .
+"
+"when you apply the counsel , you will be like soft clay that jehovah is able to mold , and you will benefit .
+"
+"though having authority over the clay , how does jehovah show respect for our free will ?
+"
+"if we understand how jehovah molds us , it can help us to have good relationships with our brothers and sisters .
+"
+"also , we will have a positive attitude about people in our territory , including our bible students .
+"
+"in bible times , before molding clay , a potter needed to clean it and remove stones and other material .
+"
+"the great potter , jehovah , helps people who want to be molded .
+"
+"he does not force them to change , but instead , he shows them his clean standards .
+"
+"then they must decide if they will make the needed changes .
+"
+"how do bible students show that they want jehovah to mold them ?
+"
+"consider what happened to tessie , a sister in australia .
+"
+"it was very easy for her to learn what the bible says .
+"
+"however , she did not make much progress , and she did not go to the meetings .
+"
+"the sister who studied with her had prayed to jehovah and had decided to stop the study .
+"
+"at their study , tessie told her teacher why she had not made any progress .
+"
+"she said that she felt like a hypocrite because she loved to gamble .
+"
+"but now she had decided to stop gambling .
+"
+"soon , tessie started going to the meetings and showing christian qualities even though some of her former friends made fun of her .
+"
+"in time , tessie got baptized and became a regular pioneer , even while she had young children .
+"
+"it is clear that when bible students begin to make changes to please god , he will draw close to them and will mold them into valuable vessels .
+"
+"( a ) what appeals to you about having jehovah as your potter ?
+"
+"( b ) what aspects of molding will we next consider ?
+"
+"today , some potters still carefully mold clay into beautiful vessels by hand .
+"
+"in a similar way , jehovah patiently molds us using his counsel , and he closely watches to see how we will react .
+"
+"can you see that jehovah is interested in you ?
+"
+"do you see how jehovah is carefully molding you ?
+"
+"if so , what qualities will help you to stay like soft clay that jehovah can mold ?
+"
+"what traits should you avoid so that you do not become like hard clay that cannot be molded ?
+"
+"and how can parents work with jehovah to mold their children ?
+"
+"jehovah molds us using the bible , his holy spirit , and the congregation .
+"
+"he helps us to change so that we can become better people
+"
+"as the clay in the hand of the potter , so are you in my hand . ” ​ — jeremiah 18 : 6 .
+"
+"songs : 60 , 22
+"
+"what traits could harden us against jehovah’s counsel ?
+"
+"what qualities can help us to remain moldable in god’s hands ?
+"
+"how can christian parents show that jehovah is their potter ?
+"
+"why did god consider daniel to be a “ very precious man , ” and how can we be obedient like daniel ?
+"
+"when the jews were taken to babylon , they entered a city filled with idols and with people who worshipped wicked spirits .
+"
+"still , faithful jews , such as daniel and his three friends , refused to be molded by the people of babylon .
+"
+"daniel and his friends accepted jehovah as their potter and continued to worship only him .
+"
+"even though daniel lived in a bad environment most of his life , god’s angel said that he was a “ very precious man . ” ​ — daniel 10 : 11 , 19 .
+"
+"in bible times , a potter might press clay into a mold to form a certain shape .
+"
+"today , true worshippers know that jehovah is the ruler of the universe and has the authority to mold nations .
+"
+"( read jeremiah 18 : 6 . )
+"
+"god also has the authority to mold each one of us .
+"
+"however , jehovah does not force anyone to change .
+"
+"instead , he wants us to be willing to let him mold us .
+"
+"in this article , we will learn how we can remain like soft clay in god’s hands .
+"
+"we will discuss the following three questions : ( 1 ) how can we avoid displaying traits that might cause us to reject god’s counsel and become like hard clay ?
+"
+"( 2 ) how can we develop qualities that help us to remain obedient and like soft clay ?
+"
+"( 3 ) how can christian parents work with god when molding their children ?
+"
+"what traits could harden our heart ?
+"
+"“ above all the things that you guard , safeguard your heart , for out of it are the sources of life , ” says proverbs 4 : 23 .
+"
+"to keep our hearts from becoming hard , we must avoid negative traits such as pride , the practice of sin , and a lack of faith .
+"
+"if we are not careful , these could cause us to become disobedient and rebellious .
+"
+"that is what happened to king uzziah of judah .
+"
+"( read 2 chronicles 26 : 3 - 5 , 16 - 21 . )
+"
+"at first , uzziah was obedient and had a good relationship with god , so god gave him strength .
+"
+"but “ as soon as he was strong , his heart became haughty . ”
+"
+"he became so proud that he tried to burn incense at the temple even though only priests were supposed to do that .
+"
+"when the priests told him he was wrong , uzziah became very angry !
+"
+"jehovah humbled the proud king , and he was a leper until he died . ​ — proverbs 16 : 18 .
+"
+"what could happen if we failed to guard against pride ?
+"
+"if we do not avoid pride , we can start thinking that we are better than others and may begin to reject counsel given to us from the bible .
+"
+"that is what happened to an elder named jim .
+"
+"he disagreed with the other elders in the congregation about a situation .
+"
+"jim says , “ i told the brothers that they were not loving , and i left the meeting . ”
+"
+"about six months later , he moved to another congregation but was not appointed an elder there .
+"
+"jim was very disappointed .
+"
+"he was so convinced he was right that he stopped serving jehovah and was inactive for ten years .
+"
+"he says that he was proud and that he began to blame jehovah for what was happening .
+"
+"for years , brothers visited him and tried to help him , but jim refused their help .
+"
+"jim says , “ i just could not stop focusing on how the others seemed to be wrong . ”
+"
+"his example shows us that pride can cause us to defend our wrong conduct .
+"
+"when that happens , we are no longer like soft clay .
+"
+"have you ever been offended by a brother or sister ?
+"
+"were you ever sad because you lost a privilege ?
+"
+"did you become proud , or did you realize that making peace with your brother and maintaining loyalty to jehovah are most important ? ​ — read psalm 119 : 165 ; colossians 3 : 13 .
+"
+"what can happen if we practice sin ?
+"
+"when a person continues to sin and even hides what he is doing , it may be hard for him to accept divine counsel .
+"
+"it can then become easier to sin .
+"
+"one brother said that in time his improper conduct did not bother him much at all . another brother , who for a time had the habit of watching pornography , later said , “ i found myself developing a critical attitude toward the elders . ”
+"
+"his habit damaged his relationship with jehovah .
+"
+"when others discovered what he was doing , he got help from the elders .
+"
+"it is true that all of us are imperfect .
+"
+"but if we become critical of those who counsel us or if we make excuses when we do something wrong instead of asking god to forgive us and help us , our heart may become hard .
+"
+"the disobedient israelites died in the wilderness because of their hardened hearts and lack of faith
+"
+"7 , 8 . ( a ) how did the ancient israelites demonstrate the hardening effect of a lack of faith ?
+"
+"( b ) what is the lesson for us ?
+"
+"when jehovah freed the israelites from egypt , they saw him perform many amazing miracles .
+"
+"despite that , as they got close to the promised land , their hearts became hard .
+"
+"they did not have faith in god .
+"
+"instead of trusting in jehovah , they became afraid and complained against moses .
+"
+"they even wanted to go back to egypt , where they had been slaves !
+"
+"jehovah was deeply hurt and said : “ how much longer will this people treat me without respect ? ”
+"
+"those israelites died in the wilderness because of their hardened hearts and lack of faith .
+"
+"today , we are very close to the new world , and our faith is being tested .
+"
+"so we need to examine the quality of our faith .
+"
+"how can we make sure that it is strong ?
+"
+"we could examine jesus ’ words found at matthew 6 : 33 .
+"
+"ask yourself : ‘ do my goals and decisions prove that i truly believe jesus ’ words ?
+"
+"would i miss meetings or field service to make more money ?
+"
+"what will i do if my job demands more of my time and energy ?
+"
+"will i allow this world to mold me and perhaps even stop me from serving jehovah ? ’
+"
+"why should we “ keep testing ” whether we are in the faith , and how can we do so ?
+"
+"if we do not follow what the bible says about bad associations , disfellowshipping , or entertainment , our heart can become hard .
+"
+"what should you do if this starts happening to you ?
+"
+"you urgently need to examine your faith !
+"
+"the bible says : “ keep testing whether you are in the faith ; keep proving what you yourselves are . ”
+"
+"be honest with yourself , and regularly use god’s word to correct your thinking .
+"
+"what can help us to be like soft clay in jehovah’s hands ?
+"
+"to help us remain like soft clay , god has given us his word , the christian congregation , and the ministry .
+"
+"when we read the bible and meditate on it daily , it helps us to become soft in jehovah’s hands and allows him to mold us .
+"
+"jehovah commanded the kings of israel to write a copy of god’s law and read it daily .
+"
+"the apostles knew that reading the scriptures and meditating on them was very important for their ministry .
+"
+"they used portions of the hebrew scriptures hundreds of times in their writings , and when they preached to people , they encouraged them to use the scriptures as well .
+"
+"in a similar way , we too see that it is important to read god’s word daily and meditate on it .
+"
+"this helps us to remain humble , and jehovah will thus be able to mold us .
+"
+"use godʼs provisions to help you remain like soft clay ( see paragraphs 10 - 13 )
+"
+"how can jehovah use the christian congregation to mold us according to our individual needs ?
+"
+"jehovah knows what each one of us needs , and he uses the christian congregation to mold us .
+"
+"jim , mentioned earlier , began to change his attitude when an elder showed interest in him .
+"
+"jim says : “ not once did he blame me for my situation or criticize me .
+"
+"instead , he remained positive and expressed a sincere desire to help . ”
+"
+"after about three months , the elder invited jim to a meeting .
+"
+"jim says that the congregation kindly welcomed him and that their love helped him to change his thinking .
+"
+"he began to see that his feelings were not the most important thing .
+"
+"the elders in jim’s congregation and his wife encouraged him , and he gradually returned to serving jehovah .
+"
+"jim also benefited from reading the articles “ jehovah is not to blame ” and “ serve jehovah loyally , ” found in the watchtower of november 15 , 1992 .
+"
+"in time , jim became an elder again .
+"
+"since then , he has helped other brothers to solve similar problems and strengthen their faith .
+"
+"he says that he thought he had a close relationship with jehovah but that he actually did not !
+"
+"he regrets that he allowed pride to cause him to focus on other people’s faults rather than on the more important things . ​ — 1 corinthians 10 : 12 .
+"
+"when we imitate christ , people are attracted to our message and may change their attitude toward us
+"
+"the field ministry can help us to cultivate what qualities , and with what benefits ?
+"
+"the field ministry can also mold us and help us to become better people .
+"
+"when we preach the good news , we must show qualities such as humility and the different aspects of the fruitage of god’s spirit .
+"
+"think of good qualities that the field ministry has helped you to develop .
+"
+"when we imitate christ , people are attracted to our message and may change their attitude toward us .
+"
+"for example , two witnesses in australia tried to preach to a woman at her home , but she got very angry and was rude to them .
+"
+"however , the witnesses listened to her respectfully .
+"
+"later , the woman regretted her behavior and wrote a letter to the branch office .
+"
+"she apologized for her behavior .
+"
+"she said , “ i am a fool to stand before two people spreading god’s word and attempt to steer them away like that . ”
+"
+"from this experience , we can see the value of being mild when we preach .
+"
+"yes , our ministry helps others , but it also helps us to improve our personality .
+"
+"what must parents do if they want to be truly effective in molding their children ?
+"
+"most little children are humble and eager to learn .
+"
+"so it is wise for parents to help their children to learn the truth and to love it while the children are still young .
+"
+"to be successful , parents must love the truth themselves and apply what the bible says in their own lives .
+"
+"when parents do this , it becomes easier for their children to love the truth .
+"
+"also , children will understand that discipline from their parents shows that they are loved by them and by jehovah .
+"
+"how should parents demonstrate their trust in god if their child is disfellowshipped ?
+"
+"even when parents teach their children the truth , some children leave jehovah or are disfellowshipped .
+"
+"if that happens , the family suffers very much . one sister in south africa said : “ when my brother was disfellowshipped , it was as if he had died .
+"
+"it was heartbreaking ! ”
+"
+"but what did she and her parents do ?
+"
+"they followed the instructions found in the bible .
+"
+"( read 1 corinthians 5 : 11 , 13 . )
+"
+"the parents knew that obeying god’s counsel would benefit everyone .
+"
+"and they recognized that disfellowshipping is loving discipline from jehovah .
+"
+"so they contacted their son only when it was absolutely necessary for family business .
+"
+"how did the son feel ?
+"
+"later he said , “ i knew that my family did not hate me , but they were obeying jehovah and his organization . ”
+"
+"he also said , “ when you are forced to beg jehovah for help and forgiveness , you realize how much you need him . ”
+"
+"imagine the family’s joy when this young man came back to jehovah !
+"
+"yes , we will be happy and successful when we always obey god . ​ — proverbs 3 : 5 , 6 ; 28 : 26 .
+"
+"when we are humble and always obey jehovah , we become very precious to him
+"
+"why should we make submission to jehovah our way of life , and how will this course benefit us ?
+"
+"the prophet isaiah foretold that the jews in babylon would repent and say : “ o jehovah , you are our father .
+"
+"we are the clay , and you are our potter ; we are all the work of your hand . ”
+"
+"they would also beg jehovah : “ do not remember our error forever .
+"
+"look at us , please , for we are all your people . ”
+"
+"when we are humble and always obey jehovah , we become very precious to him , as daniel was .
+"
+"jehovah will continue to mold us using his word , spirit , and organization so that in the future we will become perfect “ children of god . ” ​ — romans 8 : 21 .
+"
+"our heart can become hard when we allow negative traits , such as pride , to make us reject counsel and direction from jehovah and his organization
+"
+"the man with the secretary’s inkhorn represents jesus christ .
+"
+"he is the one who marks those who will survive
+"
+"they represent forces in heaven that were involved in the destruction of jerusalem and that will also be involved in the destruction of satan’s wicked world at armageddon .
+"
+"this is an adjusted understanding .
+"
+"before 607 b.c.e . , jehovah gave ezekiel a vision of what would happen in jerusalem before it was destroyed .
+"
+"in the vision , ezekiel saw many wicked things happening there .
+"
+"then he saw six men who each had a “ weapon for smashing in his hand . ”
+"
+"there was also a man with them who was “ clothed in linen ” and had “ a secretary’s inkhorn . ”
+"
+"this man was told to go through the city “ and put a mark on the foreheads of the men who are sighing and groaning over all the detestable things that are being done in the city . ”
+"
+"then the six men with the weapons were told to kill all those in the city who did not have the mark .
+"
+"what can we learn from this vision , and who is the man with the secretary’s inkhorn ?
+"
+"ezekiel had this vision in 612 b.c.e .
+"
+"it was a prophecy that was first fulfilled five years later when jehovah allowed the babylonian army to destroy jerusalem .
+"
+"in this way , jehovah used the babylonians to punish his disobedient people .
+"
+"but what about the righteous jews who did not agree with all the bad things that were happening in the city ?
+"
+"jehovah made sure that they were saved .
+"
+"in the vision , ezekiel did not literally mark anyone or take part in the destruction of the city .
+"
+"instead , it was the angels who directed the destruction of jerusalem .
+"
+"so this prophecy gives us the opportunity to see what happens in heaven .
+"
+"jehovah told his angels to organize the destruction of the wicked and to make sure that the righteous ones would survive .
+"
+"this prophecy will also be fulfilled in the future .
+"
+"we used to say that the man with the secretary’s inkhorn represented the anointed who are still alive on the earth .
+"
+"we also said that people were being marked for survival when they listened to and accepted the good news that we preach .
+"
+"recently , though , it became clear that we needed to change how we explain this prophecy .
+"
+"we have learned from matthew 25 : 31 - 33 that jesus is the one who judges people .
+"
+"he will do this in the future during the great tribulation .
+"
+"at that time , those who are judged as sheep will survive , and those who are judged as goats will be destroyed .
+"
+"so , what do we learn from ezekiel’s vision ?
+"
+"here are five lessons :
+"
+"before jerusalem was destroyed , ezekiel , as well as jeremiah and isaiah , warned the people about what was going to happen to the city .
+"
+"they were like watchmen .
+"
+"today , jehovah uses a small group of anointed ones to teach his people and warn others before the great tribulation starts .
+"
+"in fact , all of god’s people , that is , christ’s domestics , have a share in this warning work . ​ — matthew 24 : 45 - 47 .
+"
+"ezekiel did not mark those who would survive .
+"
+"neither do god’s people today .
+"
+"they simply preach to others and warn them about what will happen in the future .
+"
+"this worldwide preaching work is done with the help of the angels . ​ — revelation 14 : 6 .
+"
+"those who were saved in ezekiel’s time did not have an actual mark on their foreheads .
+"
+"today those who will be saved will also not have an actual mark .
+"
+"what must people do to survive the great tribulation ?
+"
+"when they hear the warning , they must learn to imitate christ , dedicate themselves to god , and support christ’s brothers by preaching the good news .
+"
+"during the great tribulation , these ones will be given the mark , that is , they will be chosen to survive .
+"
+"the man with the inkhorn represents jesus .
+"
+"during the great tribulation , jesus will mark the great crowd when he judges them as sheep .
+"
+"then they will have the opportunity to live forever here on earth . ​ — matthew 25 : 34 , 46 .
+"
+"today the six men with the weapons for smashing represent the heavenly armies that are led by jesus .
+"
+"they will soon destroy the nations and end all wickedness . ​ — ezekiel 10 : 2 , 6 , 7 ; revelation 19 : 11 - 21 .
+"
+"the lessons we learn from this vision help us to feel confident that jehovah will not destroy righteous ones along with wicked ones .
+"
+"the lessons learned also remind us that the preaching work in our time is very important .
+"
+"everyone needs to hear the warning before the end comes ! ​ — matthew 24 : 14 .
+"
+"those who were saved , such as baruch ( jeremiah’s secretary ) , ebed - melech the ethiopian , and the rechabites , did not have an actual mark on their foreheads .
+"
+"the symbolic mark simply meant that they would survive .
+"
+"faithful anointed ones will not need to receive this mark to survive .
+"
+"instead , they will receive their final sealing either before they die or before the start of the great tribulation . ​ — revelation 7 : 1 , 3 .
+"
+"“ listen , o israel : jehovah our god is one jehovah . ” ​ — deuteronomy 6 : 4 .
+"
+"songs : 138 , 112
+"
+"how can we show that we worship jehovah as “ one jehovah ” ?
+"
+"what can we do to maintain our peace and unity ?
+"
+"1 , 2 . ( a ) why are the words of deuteronomy 6 : 4 so well - known ?
+"
+"( b ) why did moses speak those words ?
+"
+"for hundreds of years , jewish people have used the words of deuteronomy 6 : 4 as part of a special prayer .
+"
+"this prayer is called the shema , which is the first word of that verse in hebrew .
+"
+"many jews say this prayer every day in the morning and in the evening to show their exclusive devotion to god .
+"
+"those words are part of the final talk that moses gave to the nation of israel .
+"
+"in the year 1473 before christ , the nation was in the land of moab , ready to cross the jordan river and conquer the promised land .
+"
+"moses had led the people for 40 years , and he wanted them to be courageous in order to face the difficulties that would come .
+"
+"they needed to trust in their god , jehovah , and to be faithful to him .
+"
+"so moses ’ final words encouraged them to do just that .
+"
+"after he mentioned the ten commandments and other laws from jehovah , moses gave the people the powerful reminder we read at deuteronomy 6 : 4 , 5 .
+"
+"the israelites knew that jehovah their god is “ one jehovah . ”
+"
+"faithful israelites worshipped one god , the god of their forefathers .
+"
+"so why did moses remind them that jehovah their god is “ one jehovah ” ?
+"
+"what is the connection between that truth and loving our god with our whole heart , whole soul , and whole strength ?
+"
+"and how do the words of deuteronomy 6 : 4 , 5 apply to us today ?
+"
+"4 , 5 . ( a ) what is one meaning of the phrase “ one jehovah ” ?
+"
+"( b ) how is jehovah different from the gods of the nations ?
+"
+"unique .
+"
+"the expression “ one jehovah ” means that jehovah is unique , that no one is equal to or like him .
+"
+"why did moses use that expression ? it does not seem that he was trying to prove that belief in a trinity was wrong .
+"
+"jehovah is the creator of heaven and earth and the ruler of the universe .
+"
+"he is the only true god , and no other god is like him .
+"
+"so moses ’ words would remind the israelites that they should worship only jehovah .
+"
+"they should not imitate the people living around them , who worshipped many false gods and goddesses .
+"
+"those people believed that their gods could control parts of nature .
+"
+"for example , the egyptians worshipped the sun - god ra , the sky - goddess nut , the earth - god geb , the nile - god hapi , as well as many animals .
+"
+"jehovah showed that he was superior to these false gods when he brought the ten plagues .
+"
+"the main canaanite god was baal , a false god who the canaanites believed brought life into existence .
+"
+"he was also believed to be the god of the sky , rain , and storm .
+"
+"in many places , people relied on baal for protection .
+"
+"the israelites were to remember that their god , “ the true god , ” is unique .
+"
+"he is “ one jehovah . ” ​ — deuteronomy 4 : 35 , 39 .
+"
+"jehovah god is not divided or unpredictable .
+"
+"he is always faithful , consistent , loyal , and true
+"
+"what is another meaning of “ one , ” and how did jehovah prove to be “ one ” ?
+"
+"consistent and loyal .
+"
+"the word “ one ” in the expression “ one jehovah ” also means that his purpose and actions are always reliable .
+"
+"he is always faithful , consistent , loyal , and true .
+"
+"for example , he promised abraham that his descendants would live in the promised land .
+"
+"and jehovah performed many powerful miracles in order to keep that promise .
+"
+"four hundred and thirty years after giving that promise , jehovah’s purpose had not changed . ​ — genesis 12 : 1 , 2 , 7 ; exodus 12 : 40 , 41 .
+"
+"hundreds of years later , jehovah called the israelites his witnesses and told them : “ i am the same one .
+"
+"before me no god was formed , and after me there has been none . ”
+"
+"jehovah also made it clear that his purpose never changes when he added : “ i am always the same one . ”
+"
+"what a great privilege the israelites had to serve a god who is consistent and always loyal !
+"
+"we have the same privilege today . ​ — malachi 3 : 6 ; james 1 : 17 .
+"
+"8 , 9 . ( a ) what does jehovah require of his worshippers ?
+"
+"( b ) how did jesus emphasize the import of moses ’ words ?
+"
+"yes , moses reminded the israelites that jehovah’s love and care for them would never change .
+"
+"in return , jehovah expected them to give him their exclusive devotion and to love him with their whole heart , soul , and strength .
+"
+"parents were to teach their children about jehovah at every opportunity so that young ones too would worship only jehovah . ​ — deuteronomy 6 : 6 - 9 .
+"
+"jehovah never changes his purpose , so he will never change his basic requirements for his true worshippers .
+"
+"if we want jehovah to be pleased with our worship , we must give him exclusive devotion and love him with our whole heart , mind , and strength .
+"
+"jesus said that this is the most important commandment .
+"
+"( read mark 12 : 28 - 31 . )
+"
+"let us learn how we can show by our actions that we believe that “ jehovah our god is one jehovah . ”
+"
+"10 , 11 . ( a ) in what sense is our worship of jehovah exclusive ?
+"
+"( b ) how did hebrew youths in babylon demonstrate their exclusive devotion to jehovah ?
+"
+"jehovah is our one and only god .
+"
+"we give him our exclusive devotion when we worship only him .
+"
+"we cannot worship any other gods or include any false ideas or practices in our worship to jehovah .
+"
+"he is not simply a god who is above other gods or who is more powerful than them .
+"
+"he is the true god .
+"
+"we should worship only jehovah . ​ — read revelation 4 : 11 .
+"
+"in the book of daniel , we read about the young hebrew men daniel , hananiah , mishael , and azariah .
+"
+"they showed their exclusive devotion to jehovah by refusing to eat foods that were unclean for worshippers of jehovah .
+"
+"and daniel’s three friends refused to bow down to an idol , nebuchadnezzar’s golden image .
+"
+"for them , jehovah came first .
+"
+"they were completely loyal to him . ​ — daniel 1 : 1 – 3 : 30 .
+"
+"jehovah must have first place in our life
+"
+"in giving jehovah exclusive devotion , against what must we be on guard ?
+"
+"jehovah must have first place in our life .
+"
+"if we want to give him our exclusive devotion , we must be careful that other things do not take his place .
+"
+"what could those things be ?
+"
+"in the ten commandments , jehovah said that his people should not worship other gods .
+"
+"they should not practice any kind of idolatry .
+"
+"today , there are many kinds of idolatry , and some of these may be hard to recognize .
+"
+"but jehovah has not changed his requirements .
+"
+"he is still “ one jehovah . ”
+"
+"let us see how we can avoid idolatry today .
+"
+"what could we begin to love more than jehovah ?
+"
+"at colossians 3 : 5 ( read ) , we read about things that could ruin our exclusive friendship with jehovah .
+"
+"we see that greediness is related to idolatry .
+"
+"when we have a strong desire for something , such as for a lot of money or luxuries , it can control our life , like a powerful god .
+"
+"all the sins mentioned at colossians 3 : 5 are related to greediness , which is a type of idolatry .
+"
+"so if we have a strong desire for these things , we could begin to love them more than we love god .
+"
+"then jehovah would not be “ one jehovah ” to us .
+"
+"what warning did the apostle john give regarding our love for god ?
+"
+"the apostle john emphasized something similar .
+"
+"he warned that if anyone loves the things in the world , that is , “ the desire of the flesh and the desire of the eyes and the showy display of one’s means of life , ” then “ the love of the father is not in him . ”
+"
+"so we need to examine ourselves regularly to see whether we love the world .
+"
+"we may discover that we have started to be attracted to the entertainment , people , and styles of dress and grooming of this world .
+"
+"or we may want to achieve “ great things ” by seeking higher education .
+"
+"the new world is very near .
+"
+"so we need to remember moses ’ powerful words !
+"
+"if we understand and really believe that “ jehovah our god is one jehovah , ” we will give him our exclusive devotion and serve him the way that he wants . ​ — hebrews 12 : 28 , 29 .
+"
+"why did paul remind christians that god is “ one jehovah ” ?
+"
+"the expression “ one jehovah ” helps us to understand that jehovah wants his servants to be united and to have the same purpose in life .
+"
+"in the early christian congregation , there were jews , greeks , romans , and people of other nationalities .
+"
+"they had different backgrounds , customs , and preferences .
+"
+"because of that , it was difficult for some of them to accept a new way of worship or to abandon their former practices .
+"
+"so paul needed to remind them that christians have one god , jehovah . ​ — read 1 corinthians 8 : 5 , 6 .
+"
+"jehovah wants his servants to be united and to have the same purpose in life
+"
+"16 , 17 . ( a ) what prophecy is being fulfilled in our day , and with what result ?
+"
+"( b ) what could undermine our unity ?
+"
+"what about the christian congregation today ?
+"
+"the prophet isaiah said that “ in the final part of the days , ” people from all nations would come together to worship jehovah .
+"
+"they would say : “ he will instruct us about his ways , and we will walk in his paths . ”
+"
+"we are happy to see this prophecy being fulfilled today !
+"
+"our brothers and sisters come from different places , speak different languages , and have different cultures .
+"
+"but we are united in our worship to jehovah .
+"
+"however , because we are so different , sometimes there may be difficulties .
+"
+"are you working hard to keep the christian congregation united ?
+"
+"( see paragraphs 16 - 19 )
+"
+"for example , how do you feel about brothers and sisters who are from different cultures ?
+"
+"their language , clothing , manners , and food may be very different from yours .
+"
+"do you avoid them and mainly spend time with those you have things in common with ?
+"
+"how do you feel about the elders in your area who are younger than you or who are from a different race or culture ?
+"
+"if we are not careful , we may allow those differences to affect us and damage our unity .
+"
+"18 , 19 . ( a ) what counsel is mentioned at ephesians 4 : 1 - 3 ?
+"
+"( b ) what can we do to help the congregation stay united ?
+"
+"how can we avoid such difficulties ?
+"
+"paul gave practical advice to christians living in ephesus , a rich city with people from many different backgrounds .
+"
+"paul mentioned qualities such as humility , mildness , patience , and love .
+"
+"these qualities are like strong pillars that keep a house standing .
+"
+"but to keep a house in good condition , hard work is also needed .
+"
+"paul wanted the christians in ephesus to work hard to “ maintain the oneness of the spirit . ”
+"
+"all of us must do our best to keep the congregation united .
+"
+"first , we need to cultivate and show the qualities that paul mentioned : humility , mildness , patience , and love .
+"
+"second , we need to work hard to promote “ the uniting bond of peace . ”
+"
+"misunderstandings are like small cracks in our unity ; thus , we need to work hard to resolve these misunderstandings so that we keep peace and unity among us .
+"
+"how can we demonstrate that we understand that “ jehovah our god is one jehovah ” ?
+"
+"“ jehovah our god is one jehovah . ”
+"
+"that is a powerful statement !
+"
+"that reminder strengthened the israelites to endure difficulties when they entered and conquered the promised land .
+"
+"those words can strengthen us too so that we can make it through the great tribulation and contribute to the paradise to come .
+"
+"let us continue to give jehovah our exclusive devotion .
+"
+"we need to love and serve him with our whole heart , mind , and strength , and we need to work hard to keep peace and unity with our brothers .
+"
+"if we continue to do those things , jesus will judge us as sheep and we will see his words come true : “ come , you who have been blessed by my father , inherit the kingdom prepared for you from the founding of the world . ” ​ — matthew 25 : 34 .
+"
+"we give jehovah our exclusive devotion when we worship only him and give him the first place in our life .
+"
+"we love him with all our heart , mind , and strength
+"
+"there are many fishing villages along the coasts of trinidad and tobago .
+"
+"jehovah’s witnesses often take the opportunity to speak with fishermen they meet
+"
+"why is god’s organization special ?
+"
+"how does the bible show that we are all imperfect ?
+"
+"what can we do about our own faults and those of others ?
+"
+"how did the bible foretell the increase of jehovah’s people ?
+"
+"around the earth , there is an organization made up of people who love jehovah and want to serve him .
+"
+"although they have faults and make mistakes , jehovah guides his people with his holy spirit .
+"
+"let us see some ways he has blessed them .
+"
+"in 1914 , very few people worshipped jehovah .
+"
+"but jehovah has blessed the preaching work .
+"
+"as a result , millions have learned bible truths and have become his witnesses .
+"
+"jehovah described this amazing increase when he said : “ the little one will become a thousand and the small one a mighty nation .
+"
+"today we can see clearly that this prophecy has been fulfilled .
+"
+"jehovah’s people are like a large nation .
+"
+"in fact , there are many nations around the world with a smaller population than the total number of jehovah’s people .
+"
+"how have god’s servants shown love ?
+"
+"during these last days , jehovah has helped his people to strengthen their love for one another .
+"
+"“ god is love , ” and they imitate him .
+"
+"jesus commanded his followers to “ love one another . ”
+"
+"he also told them : “ by this all will know that you are my disciples ​ — if you have love among yourselves . ”
+"
+"in recent times , jehovah’s servants have shown this love for one another even when nations have gone to war .
+"
+"for example , in the second world war , about 55 million people were killed .
+"
+"but jehovah’s people did not kill anyone in that war .
+"
+"( read micah 4 : 1 , 3 . )
+"
+"this has helped them to remain “ clean from the blood of all men . ” ​ — acts 20 : 26 .
+"
+"why is the increase of jehovah’s people noteworthy ?
+"
+"god’s people continue to increase in number even though they have a powerful enemy , satan .
+"
+"he is “ the god of this system of things . ”
+"
+"satan controls the political organizations of this world , as well as the news media , and he uses these to try to stop the preaching of the good news .
+"
+"but he cannot stop this work .
+"
+"however , satan knows that he has only a short time left , so he keeps on trying to stop us from worshipping jehovah . ​ — revelation 12 : 12 .
+"
+"why may others at times hurt our feelings ?
+"
+"god’s servants learn that it is very important to love god and other people .
+"
+"however , the bible shows that all humans are born imperfect as a result of adam’s sin .
+"
+"( read romans 5 : 12 , 19 . )
+"
+"so at times some in the congregation may say or do something that hurts our feelings .
+"
+"when this happens , what will we do ?
+"
+"will our love for jehovah stay strong ?
+"
+"will we be loyal to him and to his people ?
+"
+"the bible tells us about some of god’s servants who said or did things that hurt others .
+"
+"let us see what we can learn from what happened to them .
+"
+"if you had lived in israel at the time of eli and his sons , how would you have reacted ?
+"
+"in what sense did eli fail to discipline his sons ?
+"
+"for example , eli was the high priest of israel , but his two sons disobeyed jehovah’s laws .
+"
+"the bible says : “ the sons of eli were wicked men ; they had no regard for jehovah . ”
+"
+"eli knew that his sons were doing very bad things .
+"
+"even so , he did not discipline them enough .
+"
+"in time , jehovah punished eli and his two sons .
+"
+"and later on , he no longer allowed eli’s descendants to serve as high priests .
+"
+"if you had lived in eli’s time and had known that he let his sons do terrible things , would you have been stumbled ?
+"
+"would this situation have weakened your faith in jehovah , and as a result , would you have stopped serving him ?
+"
+"how did david sin seriously , and what did god do about it ?
+"
+"david had wonderful qualities , and that is why jehovah loved him very much .
+"
+"but even david did something very bad .
+"
+"when uriah was away fighting in a war , david had sexual relations with uriah’s wife , bath - sheba , and she became pregnant .
+"
+"david did not want anyone to know what he had done .
+"
+"so he ordered uriah to come see him and then tried to convince him to go to his home .
+"
+"david hoped that uriah would have sexual relations with bath - sheba so that people would think that uriah was the father of the baby .
+"
+"but uriah would not go home .
+"
+"so david made sure that uriah would be killed in the battle .
+"
+"because of his serious sins , david and his family suffered very much .
+"
+"yet jehovah was merciful and forgave him .
+"
+"he knew that david wanted to do what was right .
+"
+"if you had lived back then , how would you have felt about what david did ?
+"
+"would you have stopped serving jehovah ?
+"
+"( a ) how did the apostle peter fail to keep his word ?
+"
+"( b ) after peter’s mistake , why did jehovah continue to use peter ?
+"
+"another bible example is the apostle peter .
+"
+"jesus chose him to be an apostle .
+"
+"even so , peter at times said or did things that were not right .
+"
+"for example , peter said that he would never abandon jesus even if everyone else did .
+"
+"but after jesus was arrested , all the apostles , including peter , abandoned him .
+"
+"then , three different times , peter said that he did not know jesus .
+"
+"however , peter felt deeply sad about what he had done .
+"
+"so jehovah forgave him and continued to use him .
+"
+"if you had been a disciple at that time and had known what peter did , would you have continued to trust in jehovah ?
+"
+"we can be absolutely sure that jehovah will always do what is right and just
+"
+"why do you trust that god is always just ?
+"
+"from these examples , we see that some servants of jehovah have done bad things and have hurt others deeply .
+"
+"when this happens today , what will you do ?
+"
+"will you stop going to the meetings or even abandon jehovah and his people completely ?
+"
+"or will you realize that jehovah is merciful and that he may be waiting for a person to repent ?
+"
+"but there may be times when someone who is guilty of serious sins does not feel sorry about what he has done .
+"
+"will you trust that jehovah knows this and that he will do something about it at the proper time ?
+"
+"he may even remove that person from the congregation if necessary .
+"
+"do you believe that jehovah will always do what is right and just ?
+"
+"what did jesus understand about the faults of judas iscariot and peter ?
+"
+"in the bible , we read about many who remained loyal to jehovah and his people even though others around them made serious mistakes .
+"
+"jesus is the best example .
+"
+"after spending a night praying for his father’s help , he chose the 12 apostles .
+"
+"but one of them , judas iscariot , later betrayed him .
+"
+"also , the apostle peter said that he did not know jesus .
+"
+"jesus did not blame jehovah or the rest of the disciples when some disappointed him .
+"
+"jesus stayed close to his father and continued to serve him loyally .
+"
+"as a result , jehovah rewarded him by resurrecting him and later making him king of the kingdom in heaven . ​ — matthew 28 : 7 , 18 - 20 .
+"
+"the bible foretold what about jehovah’s servants in this time ?
+"
+"jesus ’ example teaches us to be loyal to jehovah and his people .
+"
+"and we have good reasons to do so .
+"
+"we can see that jehovah is guiding his servants in this time of the end .
+"
+"he is helping them to preach the truth worldwide , and they are the only ones doing this work .
+"
+"they are also truly united and happy because of all that jehovah is teaching them .
+"
+"jehovah described this when he said : “ look !
+"
+"my servants will shout joyfully because of the good condition of the heart . ” ​ — isaiah 65 : 14 .
+"
+"it would be unwise and unfair to leave jehovah and his people just because someone makes a mistake
+"
+"how should we view the faults of others ?
+"
+"we are truly happy because jehovah guides us and helps us to do many good things .
+"
+"in contrast , people in satan’s world are not happy and have no real hope for the future .
+"
+"how unwise and unfair it would be to leave jehovah and his people just because someone in the congregation does or says something that is not right !
+"
+"instead , we must remain loyal to jehovah and follow his direction .
+"
+"we also need to learn how to view and react to the faults of others .
+"
+"13 , 14 . ( a ) why should we be patient with one another ?
+"
+"( b ) what promise do we want to remember ?
+"
+"what should you do if one of your brothers says or does something that hurts your feelings ?
+"
+"the bible gives this advice : “ do not be quick to take offense , for the taking of offense lodges in the bosom of fools . ”
+"
+"all of us are imperfect and make mistakes .
+"
+"so we cannot expect that our brothers will always say and do the right thing .
+"
+"and it would not be good for us to keep thinking about their mistakes .
+"
+"if we did , we might no longer feel happy while serving jehovah .
+"
+"even worse , our faith in him might weaken , and we might leave jehovah’s organization .
+"
+"then , we could not serve jehovah or hope to live in his new world .
+"
+"so , what can help you remain happy serving jehovah when others do something that troubles you ?
+"
+"always remember his comforting promise : “ look ! i am creating new heavens and a new earth ; and the former things will not be called to mind , nor will they come up into the heart . ”
+"
+"jehovah will give you these blessings if you remain loyal to him .
+"
+"what did jesus say we should do when others make mistakes ?
+"
+"of course , we are not yet in the new world .
+"
+"so if someone hurts our feelings , we need to meditate on what jehovah wants us to do .
+"
+"for example , jesus said : “ if you forgive men their trespasses , your heavenly father will also forgive you ; whereas if you do not forgive men their trespasses , neither will your father forgive your trespasses . ”
+"
+"and when peter asked jesus whether we should forgive “ up to seven times , ” jesus replied : “ i say to you , not up to seven times , but up to 77 times . ”
+"
+"jesus taught us that we should always be willing to forgive others . ​ — matthew 6 : 14 , 15 ; 18 : 21 , 22 .
+"
+"what good example did joseph set ?
+"
+"joseph’s example teaches us how to react when others disappoint us .
+"
+"joseph and his younger brother were the only sons of jacob and rachel .
+"
+"jacob had ten other sons , but he loved joseph more than all of them .
+"
+"this made them very jealous of joseph .
+"
+"in fact , they hated him so much that they sold him as a slave , and he was taken to egypt .
+"
+"after many years , the king of egypt made joseph the second most powerful person in that country because he was very impressed with joseph’s good work .
+"
+"later , joseph’s brothers came to egypt to buy food as a result of a famine .
+"
+"when they saw joseph , they did not recognize him , but he knew who they were .
+"
+"although they had treated him badly , he did not punish them .
+"
+"instead he tested them to find out if they had truly changed .
+"
+"when joseph realized that they had changed , he told them that he was their brother .
+"
+"later , he comforted them and said : “ do not be afraid .
+"
+"i will keep supplying you and your little children with food . ” ​ — genesis 50 : 21 .
+"
+"what do you want to do when others make mistakes ?
+"
+"remember that since everyone has faults , you too may offend others .
+"
+"so if you realize that you have upset someone , follow the bible’s advice .
+"
+"ask him to forgive you , and try to make peace with him .
+"
+"( read matthew 5 : 23 , 24 . )
+"
+"we like it when others forgive us .
+"
+"so we should do the same for them .
+"
+"colossians 3 : 13 tells us : “ continue putting up with one another and forgiving one another freely even if anyone has a cause for complaint against another .
+"
+"if we really love our brothers , we will not keep feeling upset about something they have done in the past .
+"
+"and if we forgive others , jehovah will forgive us too .
+"
+"so when others make mistakes , may we be merciful with them just as our father , jehovah , is merciful with us . ​ — read psalm 103 : 12 - 14 .
+"
+"we remain loyal to jehovah and to his people : when others make mistakes , we do not stop attending meetings or leave the congregation .
+"
+"instead , we trust that jehovah guides the congregation and will always do what is right .
+"
+"also , we are willing to forgive others , just as jehovah is willing to forgive us
+"
+"people view diamonds as very precious gems .
+"
+"some are worth millions of dollars .
+"
+"but is there something that god views as more precious than diamonds or other gems ?
+"
+"haykanush , an unbaptized publisher in armenia , found a passport near her home .
+"
+"inside the passport were some debit cards and a large amount of money .
+"
+"she told her husband , also an unbaptized publisher , about what she had found .
+"
+"the couple had serious financial problems and were in debt .
+"
+"but they decided to take the money to the address that was on the passport .
+"
+"the man who had lost it was amazed , and so was his family .
+"
+"haykanush and her husband explained that they were honest because of what they were learning from the bible .
+"
+"then , they used the opportunity to talk about jehovah’s witnesses and to give some literature to the family .
+"
+"the family wanted to give haykanush some money as a reward , but she would not accept it .
+"
+"the next day , the wife visited haykanush and her husband at home , and to show how thankful she was , she insisted that haykanush accept a diamond ring .
+"
+"like that family , many people would be surprised at the honesty haykanush and her husband showed .
+"
+"but was jehovah surprised ?
+"
+"how did he view their honesty ?
+"
+"was their honesty worth the effort ?
+"
+"the answers to those questions are not difficult .
+"
+"because god’s servants know that imitating jehovah’s qualities is more precious to him than diamonds , gold , or other material things .
+"
+"yes , what jehovah views as precious is different from what most people value .
+"
+"and his servants feel that their efforts to imitate jehovah’s qualities are very precious .
+"
+"we can see this from what the bible says about discernment and wisdom .
+"
+"proverbs 3 : 13 - 15 says : “ happy is the man who finds wisdom and the man who acquires discernment ; to gain it is better than gaining silver , and having it as profit is better than having gold .
+"
+"it is more precious than corals ; nothing you desire can compare to it . ”
+"
+"clearly , jehovah values such qualities more than any material treasures .
+"
+"what , then , about honesty ?
+"
+"jehovah himself is honest .
+"
+"and he inspired the apostle paul to write to the hebrew christians in the first century : “ keep praying for us , for we trust we have an honest conscience , as we wish to conduct ourselves honestly in all things . ” ​ — hebrews 13 : 18 .
+"
+"jesus christ set a good example of honesty .
+"
+"for instance , when high priest caiaphas said , “ i put you under oath by the living god to tell us whether you are the christ , the son of god ! , ” jesus was honest and identified himself as the messiah .
+"
+"he told the truth even though he knew that the sanhedrin could accuse him of being a blasphemer and that this could lead to his execution . ​ — matthew 26 : 63 - 67 .
+"
+"if we are in a situation where we might benefit materially by not telling someone all the facts or by slightly changing some facts , will we still be honest ?
+"
+"it can be difficult to be honest in these last days when many are “ lovers of themselves , lovers of money . ”
+"
+"when there is a financial crisis or when jobs are hard to find , many do not have a problem with stealing , cheating , or doing other dishonest things .
+"
+"this kind of thinking is so common that many feel that the only way to benefit materially is to be dishonest .
+"
+"even some christians have made bad decisions and for “ dishonest gain ” have lost their good reputation in the congregation . ​ — 1 timothy 3 : 8 ; titus 1 : 7 .
+"
+"most christians , however , imitate jesus .
+"
+"they realize that having qualities like those of god is more important than any riches or benefits .
+"
+"that is why young christians do not cheat to get good grades at school . honesty may not always result in receiving a reward , as haykanush did .
+"
+"still , being honest is what god says is right , and it allows us to have a clean conscience , something truly valuable .
+"
+"gagik’s example shows that .
+"
+"he says : “ before becoming a christian , i was working for a large company where the owner avoided paying taxes by reporting only a small portion of the company’s profit .
+"
+"as managing director , i was expected to come to ‘ an agreement ’ with the tax agent by bribing him to overlook the company’s fraudulent practices .
+"
+"as a result , i had the reputation of being dishonest .
+"
+"when i learned the truth , i refused to continue doing that , even though the job paid very well .
+"
+"instead , i opened my own business .
+"
+"and from day one , i legally registered my company and paid all my taxes . ” ​ — 2 corinthians 8 : 21 .
+"
+"gagik says : “ my income dropped by about half , so it was a challenge to provide for my family .
+"
+"however , i feel happier now . i have a clean conscience before jehovah .
+"
+"i am a good example for my two sons , and i have qualified for privileges in the congregation .
+"
+"among tax auditors and others with whom i do business , i now have the reputation of being an honest man . ”
+"
+"jehovah loves those who bring praise to him by imitating his wonderful qualities , including honesty .
+"
+"and when we do this , he promises to help us . he inspired king david to say : “ i was once young and now i am old , but i have not seen anyone righteous abandoned , nor his children looking for bread . ” ​ — psalm 37 : 25 .
+"
+"the experience of faithful ruth proves that .
+"
+"she loyally stayed with her mother - in - law , naomi , rather than leave her because she was old .
+"
+"ruth moved to israel , where she could worship the true god .
+"
+"she was honest and worked hard to glean , following the law’s arrangement for the poor .
+"
+"and similar to what david later experienced , jehovah never abandoned ruth and naomi .
+"
+"he also did much more than just provide for ruth materially .
+"
+"he chose her to be part of the family line of king david and even of the promised messiah ! ​ — ruth 4 : 13 - 17 ; matthew 1 : 5 , 16 .
+"
+"it may be very difficult for some of jehovah’s servants to earn enough money for their basic needs .
+"
+"yet instead of trying to find an easy but dishonest solution , they work hard and are diligent .
+"
+"by doing this , they show that god’s wonderful qualities , including honesty , are more valuable to them than any material things . ​ — proverbs 12 : 24 ; ephesians 4 : 28 .
+"
+"like ruth , christians around the world have shown faith in jehovah’s power to help them .
+"
+"they fully trust in the one who promised : “ i will never leave you , and i will never abandon you . ”
+"
+"again and again , jehovah has shown that he can and will help those who are honest at all times .
+"
+"he has always kept his promise to provide for the basic needs of his servants . ​ — matthew 6 : 33 .
+"
+"yes , humans may value diamonds and other material things .
+"
+"but we can be sure that our heavenly father values our honesty and other good qualities more , much more , than any precious gems !
+"
+"when we are honest , we can speak with a clean conscience to people in the ministry
+"

--- a/language_pairs.md
+++ b/language_pairs.md
@@ -4,7 +4,8 @@
 
 | Source | Target | Best Test BLEU | Link |
 ---------|--------|-----------|------|
-| English | Afrikaans | 45.48 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/jw300-baseline) |
+| English | Afrikaans (Autshumato) | 19.56 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/autshumato-baseline) |
+| English | Afrikaans (JW300) | 45.48 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/jw300-baseline) |
 | English | Amharic | 2.03 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-am/jw300-amharic-baseline) |
 | English | Fon | 31.07 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-fon/jw300-baseline) |
 | English | Hausa | 41.11 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-ha/opus_en_ha_baseline) |

--- a/language_pairs.md
+++ b/language_pairs.md
@@ -4,7 +4,7 @@
 
 | Source | Target | Best Test BLEU | Link |
 ---------|--------|-----------|------|
-| English | Afrikaans | 19.56 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/jw300-baseline) |
+| English | Afrikaans | 45.48 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/jw300-baseline) |
 | English | Amharic | 2.03 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-am/jw300-amharic-baseline) |
 | English | Fon | 31.07 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-fon/jw300-baseline) |
 | English | Hausa | 41.11 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-ha/opus_en_ha_baseline) |

--- a/language_pairs.md
+++ b/language_pairs.md
@@ -4,7 +4,7 @@
 
 | Source | Target | Best Test BLEU | Link |
 ---------|--------|-----------|------|
-| English | Afrikaans | 19.56 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/autshumato-baseline) |
+| English | Afrikaans | 19.56 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-af/jw300-baseline) |
 | English | Amharic | 2.03 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-am/jw300-amharic-baseline) |
 | English | Fon | 31.07 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-fon/jw300-baseline) |
 | English | Hausa | 41.11 | [link](https://github.com/masakhane-io/masakhane/tree/master/en-ha/opus_en_ha_baseline) |


### PR DESCRIPTION
* Add a notebook that gives a baseline score for English to Afrikaans translation using the JW300 dataset (Note the drastic improvement over existing Afrikaans baselines. The JW300 data might be easier or cleaner than the previous datasets, explaining the difference. However, it is perhaps more likely due to using shallower models that allow for better signal propagation.); and
* Change link in `language_paris.md` to link to better performing model as new baseline;
* Fix broken link to `language_pairs.md` in `README.md`.